### PR TITLE
terminate all engine related subprocesses

### DIFF
--- a/vscode-extensions/engine/extension/src/index.ts
+++ b/vscode-extensions/engine/extension/src/index.ts
@@ -46,6 +46,6 @@ async function startEmbeddedEngine(extensionUri: vscode.Uri) {
 
 export async function deactivate(context: vscode.ExtensionContext): Promise<void> {
   if (child) {
-    child.kill('SIGKILL');
+    child.kill('SIGINT');
   }
 }


### PR DESCRIPTION
ensures that no engine subprocesses are left after termination on macos