### PR TITLE
XIVY-12086 fix: engine activation

### DIFF
--- a/vscode-extensions/inscription/extension/package.json
+++ b/vscode-extensions/inscription/extension/package.json
@@ -33,7 +33,7 @@
     "watch": "webpack --watch --mode development"
   },
   "activationEvents": [
-    "onStartupFinished"
+    "onCommand:activateIvyEngine"
   ],
   "main": "./lib/inscription-extension.js",
   "files": [

--- a/vscode-extensions/process-editor/extension/package.json
+++ b/vscode-extensions/process-editor/extension/package.json
@@ -33,7 +33,7 @@
     "vscode": "^1.54.0"
   },
   "activationEvents": [
-    "onStartupFinished"
+    "onCommand:activateIvyEngine"
   ],
   "main": "./dist/extension.js",
   "dependencies": {


### PR DESCRIPTION
otherwise inscription and process-editor trigger the engine extension to start