### PR TITLE
Fix outline for theia

### DIFF
--- a/vscode-extensions/process-editor/extension/package.json
+++ b/vscode-extensions/process-editor/extension/package.json
@@ -76,7 +76,7 @@
         {
           "id": "ivyProcessOutline",
           "name": "Ivy Process Outline",
-          "when": "activeCustomEditorId == 'ivy.glspDiagram'"
+          "when": "ivy:hasIvyProjects"
         }
       ]
     },


### PR DESCRIPTION
- Send select actions direct to client and reveal the webview afterwards
  This is needed because the webview loose the focus on theia and will not receive any messages
- when cause for the outline does not work in theia
  use the same as the ivy project explorer