### PR TITLE
XIVY-12783 contribute our project commands to vscode explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,17 +172,17 @@
       },
       {
         "command": "ivyProjects.addBusinessProcess",
-        "title": "Business Process",
+        "title": "New Business Process",
         "category": "Axon Ivy"
       },
       {
         "command": "ivyProjects.addCallableSubProcess",
-        "title": "Callable Sub Process",
+        "title": "New Callable Sub Process",
         "category": "Axon Ivy"
       },
       {
         "command": "ivyProjects.addWebServiceProcess",
-        "title": "Web Service Process",
+        "title": "New Web Service Process",
         "category": "Axon Ivy"
       },
       {
@@ -244,7 +244,9 @@
         {
           "id": "ivyProjects",
           "name": "Axon Ivy Projects"
-        },
+        }
+      ],
+      "explorer": [
         {
           "id": "ivyProcessOutline",
           "name": "Process Outline",

--- a/package.json
+++ b/package.json
@@ -445,11 +445,6 @@
         "view": "ivyProjects",
         "contents": "You have not yet opened a folder.\n[Open Folder](command:vscode.openFolder)",
         "when": "workbenchState == empty"
-      },
-      {
-        "view": "explorer",
-        "contents": "You have not yet added a Axon Ivy Project.\n[Add Project](command:ivyProjects.addNewProject)",
-        "when": "workbenchState != empty"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -94,102 +94,107 @@
       {
         "command": "engine.openDevWfUi",
         "title": "Open Developer Workflow UI",
-        "category": "Ivy Engine"
+        "category": "Axon Ivy"
       },
       {
         "command": "engine.openEngineCockpit",
         "title": "Open Engine Cockpit",
-        "category": "Ivy Engine"
+        "category": "Axon Ivy"
       },
       {
         "command": "engine.ivyBrowserOpen",
         "title": "Open Ivy Browser",
-        "category": "Ivy Engine"
+        "category": "Axon Ivy"
       },
       {
         "command": "workflow.fit",
         "title": "Fit to Screen",
-        "category": "Ivy Process Editor",
+        "category": "Axon Ivy",
         "enablement": "activeCustomEditorId == 'ivy.glspDiagram'"
       },
       {
         "command": "workflow.center",
         "title": "Center selection",
-        "category": "Ivy Process Editor",
+        "category": "Axon Ivy",
         "enablement": "activeCustomEditorId == 'ivy.glspDiagram'"
       },
       {
         "command": "workflow.layout",
         "title": "Layout diagram",
-        "category": "Ivy Process Editor",
+        "category": "Axon Ivy",
         "enablement": "activeCustomEditorId == 'ivy.glspDiagram'"
       },
       {
         "command": "workflow.exportAsSVG",
         "title": "Export as SVG",
-        "category": "Ivy Process Editor",
+        "category": "Axon Ivy",
         "enablement": "activeCustomEditorId == 'ivy.glspDiagram'"
       },
       {
         "command": "ivyProjects.refreshEntry",
-        "title": "Refresh",
-        "category": "Ivy Project Explorer",
+        "title": "Refresh Project Explorer",
+        "category": "Axon Ivy",
         "icon": "$(refresh)"
       },
       {
-        "command": "ivyProjects.buildAll",
-        "title": "Build All",
-        "category": "Ivy Project Explorer",
+        "command": "engine.buildProjects",
+        "title": "Build all Projects",
+        "category": "Axon Ivy",
         "icon": "$(tools)"
       },
       {
-        "command": "ivyProjects.deployAll",
-        "title": "Deploy All",
-        "category": "Ivy Project Explorer",
+        "command": "engine.deployProjects",
+        "title": "Deploy all Projects",
+        "category": "Axon Ivy",
         "icon": "$(cloud-upload)"
       },
       {
         "command": "ivyProjects.buildProject",
         "title": "Build Project",
-        "category": "Ivy Project Explorer",
+        "category": "Axon Ivy",
         "icon": "$(tools)"
       },
       {
         "command": "ivyProjects.deployProject",
         "title": "Deploy Project",
-        "category": "Ivy Project Explorer",
+        "category": "Axon Ivy",
         "icon": "$(cloud-upload)"
       },
       {
         "command": "ivyProjects.buildAndDeployProject",
         "title": "Build and Deploy Project",
-        "category": "Ivy Project Explorer"
+        "category": "Axon Ivy"
       },
       {
-        "command": "ivyProjects.buildAndDeployAll",
-        "title": "Build and Deploy All",
-        "category": "Ivy Project Explorer"
+        "command": "engine.buildAndDeployProjects",
+        "title": "Build and Deploy all Projects",
+        "category": "Axon Ivy"
       },
       {
         "command": "ivyProjects.addBusinessProcess",
         "title": "Business Process",
-        "category": "Ivy Project Explorer"
+        "category": "Axon Ivy"
       },
       {
         "command": "ivyProjects.addCallableSubProcess",
         "title": "Callable Sub Process",
-        "category": "Ivy Project Explorer"
+        "category": "Axon Ivy"
       },
       {
         "command": "ivyProjects.addWebServiceProcess",
         "title": "Web Service Process",
-        "category": "Ivy Project Explorer"
+        "category": "Axon Ivy"
       },
       {
         "command": "ivyProjects.addNewProject",
-        "title": "Project",
-        "category": "Ivy Project Explorer",
+        "title": "New Project",
+        "category": "Axon Ivy",
         "icon": "$(add)"
+      },
+      {
+        "command": "ivyProjects.revealInExplorer",
+        "title": "Reveal in Explorer",
+        "category": "Axon Ivy"
       }
     ],
     "configuration": {
@@ -255,6 +260,14 @@
       {
         "id": "ivyProjects.new",
         "label": "New"
+      },
+      {
+        "id": "explorer.new",
+        "label": "Axon Ivy New..."
+      },
+      {
+        "id": "explorer.run",
+        "label": "Axon Ivy Run..."
       }
     ],
     "menus": {
@@ -292,22 +305,27 @@
           "group": "navigation@3"
         },
         {
-          "command": "ivyProjects.buildAll",
-          "when": "view == ivyProjects"
+          "command": "engine.buildProjects",
+          "when": "view == ivyProjects || view == workbench.explorer.fileView"
         },
         {
-          "command": "ivyProjects.deployAll",
-          "when": "view == ivyProjects",
+          "command": "engine.deployProjects",
+          "when": "view == ivyProjects || view == workbench.explorer.fileView",
           "group": "navigation@2"
         },
         {
-          "command": "ivyProjects.buildAndDeployAll",
-          "when": "view == ivyProjects"
+          "command": "engine.buildAndDeployProjects",
+          "when": "view == ivyProjects || view == workbench.explorer.fileView"
+        }
+      ],
+      "explorer/context": [
+        {
+          "submenu": "explorer.new",
+          "group": "1@1"
         },
         {
-          "command": "ivyProjects.addNewProject",
-          "when": "view == ivyProjects",
-          "group": "navigation@1"
+          "submenu": "explorer.run",
+          "group": "1@2"
         }
       ],
       "view/item/context": [
@@ -323,7 +341,11 @@
         },
         {
           "command": "ivyProjects.buildAndDeployProject",
-          "when": "view == ivyProjects && viewItem == ivyProject"
+          "when": "view == ivyProjects"
+        },
+        {
+          "command": "ivyProjects.revealInExplorer",
+          "when": "view == ivyProjects"
         },
         {
           "submenu": "ivyProjects.new",
@@ -343,10 +365,38 @@
         {
           "command": "ivyProjects.addWebServiceProcess",
           "group": "1_new@2"
+        }
+      ],
+      "explorer.new": [
+        {
+          "command": "ivyProjects.addBusinessProcess",
+          "group": "1_new@1"
+        },
+        {
+          "command": "ivyProjects.addCallableSubProcess",
+          "group": "1_new@2"
+        },
+        {
+          "command": "ivyProjects.addWebServiceProcess",
+          "group": "1_new@2"
         },
         {
           "command": "ivyProjects.addNewProject",
           "group": "2_new@1"
+        }
+      ],
+      "explorer.run": [
+        {
+          "command": "ivyProjects.buildAndDeployProject",
+          "group": "run@3"
+        },
+        {
+          "command": "ivyProjects.buildProject",
+          "group": "run@1"
+        },
+        {
+          "command": "ivyProjects.deployProject",
+          "group": "run@2"
         }
       ]
     },
@@ -395,8 +445,8 @@
         "when": "workbenchState == empty"
       },
       {
-        "view": "ivyProjects",
-        "contents": "You have not yet added a project.\n[Add Project](command:ivyProjects.addNewProject)",
+        "view": "explorer",
+        "contents": "You have not yet added a Axon Ivy Project.\n[Add Project](command:ivyProjects.addNewProject)",
         "when": "workbenchState != empty"
       }
     ]

--- a/playwright/tests/create-process.test.ts
+++ b/playwright/tests/create-process.test.ts
@@ -4,12 +4,12 @@ import { multiProjectWorkspacePath, removeFromWorkspace } from './workspaces/wor
 import { Page, expect } from '@playwright/test';
 import { OutputView } from './page-objects/output-view';
 import { ProcessEditor } from './page-objects/process-editor';
-import { ProjectExplorerView } from './page-objects/explorer-view';
+import { FileExplorer } from './page-objects/explorer-view';
 import path from 'path';
 
 test.describe('Create Process', () => {
   let page: Page;
-  let explorer: ProjectExplorerView;
+  let explorer: FileExplorer;
   let processEditor: ProcessEditor;
   const projectName = 'prebuiltProject';
   const cleanUp = () => removeFromWorkspace(path.join(multiProjectWorkspacePath, projectName), 'processes');
@@ -20,7 +20,7 @@ test.describe('Create Process', () => {
     page = await pageFor(multiProjectWorkspacePath, testInfo.titlePath[1]);
     const outputView = new OutputView(page);
     await outputView.checkIfEngineStarted();
-    explorer = new ProjectExplorerView(page);
+    explorer = new FileExplorer(page);
     await explorer.hasStatusMessage('Successful Project Initialization');
   });
 

--- a/playwright/tests/create-project.test.ts
+++ b/playwright/tests/create-project.test.ts
@@ -5,19 +5,20 @@ import { FileExplorer } from './page-objects/explorer-view';
 
 test.describe('Create Project', () => {
   const projectName = 'testProject';
+  const rootFolder = 'parent';
 
   test.beforeAll(async () => {
-    removeFromWorkspace(empty, projectName);
+    removeFromWorkspace(empty, rootFolder);
   });
 
   test.afterAll(async () => {
-    removeFromWorkspace(empty, projectName);
+    removeFromWorkspace(empty, rootFolder);
   });
 
   test('Add Project and execute init Process', async ({ pageFor }) => {
     const page = await pageFor(empty);
     const explorer = new FileExplorer(page);
-    await explorer.addProject(projectName);
+    await explorer.addNestedProject(rootFolder, projectName);
     await explorer.hasStatusMessage('Successful Project Deployment', 60_000);
 
     const processEditor = new ProcessEditor(page, 'BusinessProcess.p.json');

--- a/playwright/tests/create-project.test.ts
+++ b/playwright/tests/create-project.test.ts
@@ -1,7 +1,7 @@
 import { test } from './fixtures/page';
 import { ProcessEditor } from './page-objects/process-editor';
 import { empty, removeFromWorkspace } from './workspaces/workspace';
-import { ProjectExplorerView } from './page-objects/explorer-view';
+import { FileExplorer } from './page-objects/explorer-view';
 
 test.describe('Create Project', () => {
   const projectName = 'testProject';
@@ -16,9 +16,7 @@ test.describe('Create Project', () => {
 
   test('Add Project and execute init Process', async ({ pageFor }) => {
     const page = await pageFor(empty);
-    const explorer = new ProjectExplorerView(page);
-    await explorer.showAxonIvyContainer();
-    await explorer.isWelcomeViewVisible();
+    const explorer = new FileExplorer(page);
     await explorer.addProject(projectName);
     await explorer.hasStatusMessage('Successful Project Deployment', 60_000);
 

--- a/playwright/tests/engine.test.ts
+++ b/playwright/tests/engine.test.ts
@@ -32,7 +32,7 @@ test.describe('Engine', () => {
   test('ensure that embedded engine is not started due to settings', async ({ pageFor }) => {
     page = await pageFor(noEngineWorkspacePath);
     const settingsView = new SettingsView(page);
-    await settingsView.isAxonIvyActionItemChecked();
+    await settingsView.isExplorerActionItemChecked();
     await settingsView.openWorkspaceSettings();
     await settingsView.containsSetting('"runEmbeddedEngine": false');
     await settingsView.containsSetting('"engineUrl": "http://localhost:8080/"');

--- a/playwright/tests/page-objects/explorer-view.ts
+++ b/playwright/tests/page-objects/explorer-view.ts
@@ -1,5 +1,6 @@
 import { Page, expect, Locator } from '@playwright/test';
 import { View, ViewData } from './view';
+import path from 'path';
 
 export abstract class ExplorerView extends View {
   constructor(private viewName: string, page: Page) {
@@ -77,7 +78,7 @@ export class FileExplorer extends ExplorerView {
     await this.provideUserInput();
     await this.provideUserInput();
     await this.provideUserInput();
-    await this.hasNode(rootFolder + '/' + projectName);
+    await this.hasNode(rootFolder + path.sep + projectName);
   }
 
   async addProcess(

--- a/playwright/tests/page-objects/explorer-view.ts
+++ b/playwright/tests/page-objects/explorer-view.ts
@@ -52,6 +52,10 @@ export abstract class ExplorerView extends View {
     const selected = this.viewLocator.locator('.monaco-list-row.selected');
     await expect(selected).toContainText(name);
   }
+
+  async doubleClickExpandable(name: string): Promise<void> {
+    await this.viewLocator.getByText(name).dblclick();
+  }
 }
 
 export class FileExplorer extends ExplorerView {
@@ -59,7 +63,7 @@ export class FileExplorer extends ExplorerView {
     super('Explorer', page);
   }
 
-  async addFolder(name: string) {
+  async addFolder(name: string): Promise<void> {
     await this.executeCommand('File: New Folder');
     await this.provideUserInput(name);
   }
@@ -91,14 +95,15 @@ export class ProjectExplorerView extends ExplorerView {
   constructor(page: Page) {
     super('Axon Ivy Projects', page);
   }
+
+  async revealInExplorer(name: string): Promise<void> {
+    await this.selectNode(name);
+    await this.executeCommand('Axon Ivy: Reveal in Explorer');
+  }
 }
 
 export class OutlineExplorerView extends ExplorerView {
   constructor(page: Page) {
     super('Process Outline', page);
-  }
-
-  async doubleClickExpandable(name: string): Promise<void> {
-    await this.viewLocator.getByText(name).dblclick();
   }
 }

--- a/playwright/tests/page-objects/explorer-view.ts
+++ b/playwright/tests/page-objects/explorer-view.ts
@@ -43,12 +43,6 @@ export abstract class ExplorerView extends View {
     await expect(node).not.toBeAttached();
   }
 
-  async clickAction(title: string): Promise<void> {
-    const actionLocator = this.page.getByRole('button', { name: title, exact: true });
-    await expect(actionLocator).toBeVisible();
-    await actionLocator.click();
-  }
-
   async selectNode(name: string): Promise<void> {
     await this.viewLocator.getByText(name).click();
     await this.isSelected(name);
@@ -60,6 +54,28 @@ export abstract class ExplorerView extends View {
   }
 }
 
+export class FileExplorer extends ExplorerView {
+  constructor(page: Page) {
+    super('Explorer', page);
+  }
+
+  async addFolder(name: string) {
+    await this.executeCommand('File: New Folder');
+    await this.provideUserInput(name);
+  }
+
+  async addProject(projectName: string): Promise<void> {
+    await this.viewLocator.click();
+    await this.addFolder(projectName);
+    await this.selectNode(projectName);
+    await this.executeCommand('Axon Ivy: New Project');
+    await this.provideUserInput(projectName);
+    await this.provideUserInput();
+    await this.provideUserInput();
+    await this.provideUserInput();
+  }
+}
+
 export class ProjectExplorerView extends ExplorerView {
   constructor(page: Page) {
     super('Axon Ivy Projects', page);
@@ -67,14 +83,6 @@ export class ProjectExplorerView extends ExplorerView {
 
   async isWelcomeViewVisible(): Promise<void> {
     await expect(this.page.locator('.welcome-view-content')).toBeVisible();
-  }
-
-  async addProject(projectName: string): Promise<void> {
-    await this.clickAction('Project');
-    await this.provideUserInput(projectName);
-    await this.provideUserInput();
-    await this.provideUserInput();
-    await this.provideUserInput();
   }
 
   async addProcess(

--- a/playwright/tests/page-objects/explorer-view.ts
+++ b/playwright/tests/page-objects/explorer-view.ts
@@ -64,25 +64,16 @@ export class FileExplorer extends ExplorerView {
     await this.provideUserInput(name);
   }
 
-  async addProject(projectName: string): Promise<void> {
+  async addNestedProject(rootFolder: string, projectName: string): Promise<void> {
     await this.viewLocator.click();
-    await this.addFolder(projectName);
-    await this.selectNode(projectName);
+    await this.addFolder(rootFolder);
+    await this.selectNode(rootFolder);
     await this.executeCommand('Axon Ivy: New Project');
     await this.provideUserInput(projectName);
     await this.provideUserInput();
     await this.provideUserInput();
     await this.provideUserInput();
-  }
-}
-
-export class ProjectExplorerView extends ExplorerView {
-  constructor(page: Page) {
-    super('Axon Ivy Projects', page);
-  }
-
-  async isWelcomeViewVisible(): Promise<void> {
-    await expect(this.page.locator('.welcome-view-content')).toBeVisible();
+    await this.hasNode(rootFolder + '/' + projectName);
   }
 
   async addProcess(
@@ -91,8 +82,14 @@ export class ProjectExplorerView extends ExplorerView {
     kind: 'Business Process' | 'Callable Sub Process' | 'Web Service Process'
   ): Promise<void> {
     await this.selectNode(projectName);
-    await this.executeCommand('Ivy Project Explorer: ' + kind);
+    await this.executeCommand('Axon Ivy: New ' + kind);
     await this.provideUserInput(processName);
+  }
+}
+
+export class ProjectExplorerView extends ExplorerView {
+  constructor(page: Page) {
+    super('Axon Ivy Projects', page);
   }
 }
 

--- a/playwright/tests/page-objects/page-object.ts
+++ b/playwright/tests/page-objects/page-object.ts
@@ -12,6 +12,10 @@ export abstract class PageObject {
     await this.isActionItemChecked('Axon Ivy');
   }
 
+  async isExplorerActionItemChecked() {
+    await this.isActionItemChecked('Explorer');
+  }
+
   async isActionItemChecked(label: string) {
     await expect(this.page.locator('li.action-item.checked').getByLabel(label).first()).toBeVisible();
   }

--- a/playwright/tests/project-explorer.test.ts
+++ b/playwright/tests/project-explorer.test.ts
@@ -6,18 +6,21 @@ test.describe('Project Explorer', () => {
   test('Ensure Project Explorer is hidden as there is no Ivy Project', async ({ pageFor }) => {
     const page = await pageFor(noProjectWorkspacePath);
     const explorer = new ProjectExplorerView(page);
+    await explorer.showAxonIvyContainer();
     await explorer.isHidden();
   });
 
   test('Ensure Process Outline Explorer is hidden as there is no Ivy Project', async ({ pageFor }) => {
     const page = await pageFor(noProjectWorkspacePath);
     const explorer = new OutlineExplorerView(page);
+    await explorer.showAxonIvyContainer();
     await explorer.isHidden();
   });
 
   test('Verify that Project Explorer lists several Ivy Projects', async ({ pageFor }) => {
     const page = await pageFor(multiProjectWorkspacePath);
     const explorer = new ProjectExplorerView(page);
+    await explorer.showAxonIvyContainer();
     await explorer.hasNode('ivy-project-1');
     await explorer.hasNode('ivy-project-2');
     await explorer.hasNoNode('ivy-project-3');

--- a/playwright/tests/project-explorer.test.ts
+++ b/playwright/tests/project-explorer.test.ts
@@ -31,7 +31,7 @@ test.describe('Project Explorer', () => {
     const page = await pageFor(multiProjectWorkspacePath);
     const explorer = new ProjectExplorerView(page);
     await explorer.showAxonIvyContainer();
-    await explorer.doubleClickExpandable('prebuiltProject');
+    await explorer.selectNode('prebuiltProject');
     await explorer.revealInExplorer('pom.xml');
     const fileExplorer = new FileExplorer(page);
     await fileExplorer.isSelected('pom.xml');

--- a/playwright/tests/project-explorer.test.ts
+++ b/playwright/tests/project-explorer.test.ts
@@ -1,5 +1,5 @@
 import { test } from './fixtures/page';
-import { OutlineExplorerView, ProjectExplorerView } from './page-objects/explorer-view';
+import { FileExplorer, OutlineExplorerView, ProjectExplorerView } from './page-objects/explorer-view';
 import { multiProjectWorkspacePath, noProjectWorkspacePath } from './workspaces/workspace';
 
 test.describe('Project Explorer', () => {
@@ -25,5 +25,15 @@ test.describe('Project Explorer', () => {
     await explorer.hasNode('ivy-project-2');
     await explorer.hasNoNode('ivy-project-3');
     await explorer.hasNoNode('no-ivy-project');
+  });
+
+  test('Reveal in Explorer', async ({ pageFor }) => {
+    const page = await pageFor(multiProjectWorkspacePath);
+    const explorer = new ProjectExplorerView(page);
+    await explorer.showAxonIvyContainer();
+    await explorer.doubleClickExpandable('prebuiltProject');
+    await explorer.revealInExplorer('pom.xml');
+    const fileExplorer = new FileExplorer(page);
+    await fileExplorer.isSelected('pom.xml');
   });
 });

--- a/playwright/tests/variables-editor.test.ts
+++ b/playwright/tests/variables-editor.test.ts
@@ -13,7 +13,7 @@ test.describe('Variables Editor', () => {
 
   test.beforeEach(async () => {
     editor = new VariablesEditor(page);
-    await editor.isAxonIvyActionItemChecked();
+    await editor.isExplorerActionItemChecked();
     await editor.openEditorFile();
     await editor.isTabVisible();
     await editor.isViewVisible();

--- a/src/base/commands.ts
+++ b/src/base/commands.ts
@@ -7,7 +7,8 @@ export async function executeCommand(command: Command, ...rest: any[]) {
 export async function registerCommand(command: Command, callback: (...args: any[]) => any) {
   commands.registerCommand(command, callback);
 }
-export type Command = 'setContext' | 'vscode.open' | EngineCommand | ProjectViewCommand | ViewCommand;
+export type Command = VSCodeCommand | EngineCommand | ProjectViewCommand | ViewCommand;
+type VSCodeCommand = 'revealInExplorer' | 'setContext' | 'vscode.open' | 'copyFilePath';
 type EngineCommand =
   | 'engine.startIvyEngineManager'
   | 'engine.deployProjects'
@@ -27,9 +28,6 @@ type EngineCommand =
   | 'process-editor.activate';
 type ProjectViewCommand =
   | 'ivyProjects.refreshEntry'
-  | 'ivyProjects.buildAll'
-  | 'ivyProjects.deployAll'
-  | 'ivyProjects.buildAndDeployAll'
   | 'ivyProjects.buildProject'
   | 'ivyProjects.deployProject'
   | 'ivyProjects.buildAndDeployProject'
@@ -37,5 +35,6 @@ type ProjectViewCommand =
   | 'ivyProjects.addCallableSubProcess'
   | 'ivyProjects.addWebServiceProcess'
   | 'ivyProjects.addNewProject'
-  | 'ivyProjects.getIvyProjects';
-type ViewCommand = 'ivyBrowserView.focus' | 'ivyProjects.focus' | 'ivyProcessOutline.selectElement';
+  | 'ivyProjects.getIvyProjects'
+  | 'ivyProjects.revealInExplorer';
+type ViewCommand = 'ivyBrowserView.focus' | 'ivyProcessOutline.selectElement';

--- a/src/project-explorer/ivy-project-tree-data-provider.ts
+++ b/src/project-explorer/ivy-project-tree-data-provider.ts
@@ -69,7 +69,7 @@ export class IvyProjectTreeDataProvider implements vscode.TreeDataProvider<Entry
   }
 
   async getIvyProjects(): Promise<string[]> {
-    return await this.ivyProjects;
+    return this.ivyProjects;
   }
 
   refresh(): void {
@@ -149,12 +149,5 @@ export class IvyProjectTreeDataProvider implements vscode.TreeDataProvider<Entry
 
   async readDirectory(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
     return (await vscode.workspace.fs.readDirectory(uri)).filter(([childName]) => !childName.startsWith('.'));
-  }
-
-  static rootOf(child: Entry): Entry {
-    if (child.parent) {
-      return this.rootOf(child.parent);
-    }
-    return child;
   }
 }

--- a/src/project-explorer/tree-selection.ts
+++ b/src/project-explorer/tree-selection.ts
@@ -1,0 +1,39 @@
+import * as vscode from 'vscode';
+import { Entry } from './ivy-project-tree-data-provider';
+import { Command, executeCommand } from '../base/commands';
+import path from 'path';
+
+export type TreeSelection = Entry | vscode.Uri | undefined;
+
+export async function executeTreeSelectionCommand(command: Command, selection: TreeSelection, ivyProjects: Promise<string[]>) {
+  treeSelectionToProjectPath(selection, ivyProjects).then(selectionPath => selectionPath && executeCommand(command, selectionPath));
+}
+
+export async function treeSelectionToProjectPath(selection: TreeSelection, ivyProjects: Promise<string[]>): Promise<string | undefined> {
+  return treeSelectionToUri(selection).then(uri => findMatchingProject(ivyProjects, uri));
+}
+
+export async function treeSelectionToUri(selection: TreeSelection): Promise<vscode.Uri> {
+  if (!selection) {
+    return selectionFromExplorer();
+  }
+  if (selection instanceof vscode.Uri) {
+    return selection;
+  }
+  return selection.uri;
+}
+
+// no api available yet, see https://github.com/microsoft/vscode/issues/3553
+async function selectionFromExplorer(): Promise<vscode.Uri> {
+  const originalClipboard = await vscode.env.clipboard.readText();
+  await executeCommand('copyFilePath');
+  const filePath = await vscode.env.clipboard.readText();
+  vscode.env.clipboard.writeText(originalClipboard);
+  return vscode.Uri.file(filePath);
+}
+
+async function findMatchingProject(ivyProjects: Promise<string[]>, selectedUri: vscode.Uri): Promise<string | undefined> {
+  return ivyProjects.then(projects =>
+    projects.find(project => selectedUri.fsPath === project || selectedUri.fsPath.startsWith(project + path.sep))
+  );
+}


### PR DESCRIPTION
- streamline command categories/names
- process outline back to explorer container
- submenus for explorer context menu
- add reveal in file explorer command to project explorer
- make create/deploy commands work with file explorer