### PR TITLE
run tests against VSCode stable & more testing stuff

### DIFF
--- a/build/integration/openvscode-server/playwright/Dockerfile
+++ b/build/integration/openvscode-server/playwright/Dockerfile
@@ -1,3 +1,4 @@
 FROM mcr.microsoft.com/playwright:v1.38.1-jammy
 
 ENV CI=true
+ENV RUN_IN_BRWOSER=true

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint:ci": "lerna run lint -- -o eslint.xml -f checkstyle",
     "package": "lerna run package",
     "test:playwright": "yarn -s --cwd playwright ui-tests",
+    "test:playwright:stable": "RUN_STABLE_VERSION=true yarn -s --cwd playwright ui-tests",
     "test:playwright:browser": "RUN_IN_BRWOSER=true yarn -s --cwd playwright ui-tests",
     "test:playwright:download:vscode": "yarn -s --cwd playwright download:vscode",
     "update:axonivy:next": "npx --yes npm-check-updates @axonivy* -ws -t patch -u"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "lint:ci": "lerna run lint -- -o eslint.xml -f checkstyle",
     "package": "lerna run package",
     "test:playwright": "yarn -s --cwd playwright ui-tests",
-    "test:playwright:stable": "RUN_STABLE_VERSION=true yarn -s --cwd playwright ui-tests",
-    "test:playwright:browser": "RUN_IN_BRWOSER=true yarn -s --cwd playwright ui-tests",
+    "test:playwright:stable": "RUN_STABLE_VERSION=true yarn test:playwright",
+    "test:playwright:browser": "RUN_IN_BRWOSER=true yarn test:playwright",
     "test:playwright:download:vscode": "yarn -s --cwd playwright download:vscode",
     "update:axonivy:next": "npx --yes npm-check-updates @axonivy* -ws -t patch -u"
   },

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   },
   testDir: './tests',
   workers: 1,
-  retries: process.env.CI ? 1 : 0,
+  retries: process.env.CI ? 2 : 0,
   timeout: process.env.CI ? 120_000 : 60_000,
   expect: { timeout: 30_000 },
   reporter: process.env.CI ? [['junit', { outputFile: 'report.xml' }]] : 'html'

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   },
   testDir: './tests',
   workers: 1,
-  retries: process.env.CI ? 3 : 0,
+  retries: process.env.CI ? 1 : 0,
   timeout: process.env.CI ? 120_000 : 60_000,
   expect: { timeout: 30_000 },
   reporter: process.env.CI ? [['junit', { outputFile: 'report.xml' }]] : 'html'

--- a/playwright/tests/create-process.test.ts
+++ b/playwright/tests/create-process.test.ts
@@ -45,6 +45,8 @@ test.describe('Create Process', () => {
     const start = processEditor.locatorForElementType('g.start\\:requestStart');
     await processEditor.appendActivityAndSave(start, 'Script');
     const script = processEditor.locatorForElementType('g.script');
+    await expect(script).toHaveClass(/selected/);
+    await processEditor.saveAllFiles();
     await processEditor.startProcessAndAssertExecuted(start, script);
   });
 

--- a/playwright/tests/create-process.test.ts
+++ b/playwright/tests/create-process.test.ts
@@ -23,7 +23,7 @@ test.describe('Create Process', () => {
   });
 
   test.afterEach(async () => {
-    await processEditor.revertAndCloseEditor();
+    await processEditor.closeAllTabs();
     await wait(page);
   });
 
@@ -38,6 +38,14 @@ test.describe('Create Process', () => {
     const start = processEditor.locatorForElementType('g.start\\:requestStart');
     const end = processEditor.locatorForElementType('g.end\\:taskEnd');
     await processEditor.startProcessAndAssertExecuted(start, end);
+  });
+
+  test('Assert that process gets redeployed after editing', async () => {
+    await explorer.addProcess(projectName, 'addScriptToMe', 'Business Process');
+    const start = processEditor.locatorForElementType('g.start\\:requestStart');
+    await processEditor.appendActivityAndSave(start, 'Script');
+    const script = processEditor.locatorForElementType('g.script');
+    await processEditor.startProcessAndAssertExecuted(start, script);
   });
 
   test('Add nested business process', async () => {

--- a/playwright/tests/create-process.test.ts
+++ b/playwright/tests/create-process.test.ts
@@ -49,7 +49,7 @@ test.describe('Create Process', () => {
   test('Assert that process gets redeployed after editing', async () => {
     await explorer.addProcess(projectName, processName, 'Business Process');
     const start = processEditor.locatorForElementType('g.start\\:requestStart');
-    await processEditor.appendActivityAndSave(start, 'Script');
+    await processEditor.appendActivity(start, 'Script');
     const script = processEditor.locatorForElementType('g.script');
     await expect(script).toHaveClass(/selected/);
     await processEditor.saveAllFiles();

--- a/playwright/tests/create-process.test.ts
+++ b/playwright/tests/create-process.test.ts
@@ -6,11 +6,13 @@ import { ProcessEditor } from './page-objects/process-editor';
 import { FileExplorer } from './page-objects/explorer-view';
 import path from 'path';
 import { wait } from './utils/timeout';
+import { randomInt } from 'crypto';
 
 test.describe('Create Process', () => {
   let page: Page;
   let explorer: FileExplorer;
   let processEditor: ProcessEditor;
+  let processName: string;
   const projectName = 'prebuiltProject';
   const cleanUp = () => removeFromWorkspace(path.join(multiProjectWorkspacePath, projectName), 'processes');
 
@@ -20,6 +22,10 @@ test.describe('Create Process', () => {
     explorer = new FileExplorer(page);
     processEditor = new ProcessEditor(page);
     await processEditor.hasStatusMessage('Finished: Deploy Ivy Projects');
+  });
+
+  test.beforeEach(async () => {
+    processName = randomInt(10_000).toString();
   });
 
   test.afterEach(async () => {
@@ -32,8 +38,8 @@ test.describe('Create Process', () => {
   });
 
   test('Add business process and execute it', async () => {
-    await explorer.addProcess(projectName, 'testBusinessProcess', 'Business Process');
-    await explorer.hasNoNode('testBusinessProcess.p.json');
+    await explorer.addProcess(projectName, processName, 'Business Process');
+    await explorer.hasNode(`${processName}.p.json`);
     await explorer.hasStatusMessage('Finished: Deploy Ivy Projects');
     const start = processEditor.locatorForElementType('g.start\\:requestStart');
     const end = processEditor.locatorForElementType('g.end\\:taskEnd');
@@ -41,7 +47,7 @@ test.describe('Create Process', () => {
   });
 
   test('Assert that process gets redeployed after editing', async () => {
-    await explorer.addProcess(projectName, 'addScriptToMe', 'Business Process');
+    await explorer.addProcess(projectName, processName, 'Business Process');
     const start = processEditor.locatorForElementType('g.start\\:requestStart');
     await processEditor.appendActivityAndSave(start, 'Script');
     const script = processEditor.locatorForElementType('g.script');
@@ -51,24 +57,24 @@ test.describe('Create Process', () => {
   });
 
   test('Add nested business process', async () => {
-    await explorer.addProcess(projectName, 'parent1/parent2/child', 'Business Process');
-    await explorer.hasNoNode('parent1');
-    await explorer.hasNoNode('parent2');
-    await explorer.hasNoNode('child.p.json');
+    await explorer.addProcess(projectName, `parent1/parent2/${processName}`, 'Business Process');
+    await explorer.hasNode('parent1');
+    await explorer.hasNode('parent2');
+    await explorer.hasNode(`${processName}.p.json`);
     const start = processEditor.locatorForElementType('g.start\\:requestStart');
     await expect(start).toBeVisible();
   });
 
   test('Add callable sub process', async () => {
-    await explorer.addProcess(projectName, 'testCallableSubProcess', 'Callable Sub Process');
-    await explorer.hasNoNode('testCallableSubProcess.p.json');
+    await explorer.addProcess(projectName, processName, 'Callable Sub Process');
+    await explorer.hasNode(`${processName}.p.json`);
     const start = processEditor.locatorForElementType('g.start\\:callSubStart');
     await expect(start).toBeVisible();
   });
 
   test('Add web service process', async () => {
-    await explorer.addProcess(projectName, 'testWebServiceProcess', 'Web Service Process');
-    await explorer.hasNoNode('testWebServiceProcess.p.json');
+    await explorer.addProcess(projectName, processName, 'Web Service Process');
+    await explorer.hasNode(`${processName}.p.json`);
     const start = processEditor.locatorForElementType('g.start\\:webserviceStart');
     await expect(start).toBeVisible();
   });

--- a/playwright/tests/create-project.test.ts
+++ b/playwright/tests/create-project.test.ts
@@ -15,7 +15,7 @@ test.describe('Create Project', () => {
     removeFromWorkspace(empty, rootFolder);
   });
 
-  test.only('Add Project and execute init Process', async ({ pageFor }) => {
+  test('Add Project and execute init Process', async ({ pageFor }) => {
     const page = await pageFor(empty);
     const explorer = new FileExplorer(page);
     await explorer.addNestedProject(rootFolder, projectName);
@@ -26,6 +26,5 @@ test.describe('Create Project', () => {
     const start = processEditor.locatorForElementType('g.start\\:requestStart');
     const end = processEditor.locatorForElementType('g.end\\:taskEnd');
     await processEditor.startProcessAndAssertExecuted(start, end);
-    await processEditor.revertAndCloseEditor();
   });
 });

--- a/playwright/tests/create-project.test.ts
+++ b/playwright/tests/create-project.test.ts
@@ -15,7 +15,7 @@ test.describe('Create Project', () => {
     removeFromWorkspace(empty, rootFolder);
   });
 
-  test('Add Project and execute init Process', async ({ pageFor }) => {
+  test.only('Add Project and execute init Process', async ({ pageFor }) => {
     const page = await pageFor(empty);
     const explorer = new FileExplorer(page);
     await explorer.addNestedProject(rootFolder, projectName);

--- a/playwright/tests/create-project.test.ts
+++ b/playwright/tests/create-project.test.ts
@@ -26,5 +26,6 @@ test.describe('Create Project', () => {
     const start = processEditor.locatorForElementType('g.start\\:requestStart');
     const end = processEditor.locatorForElementType('g.end\\:taskEnd');
     await processEditor.startProcessAndAssertExecuted(start, end);
+    await processEditor.closeAllTabs();
   });
 });

--- a/playwright/tests/create-user-dialog.test.ts
+++ b/playwright/tests/create-user-dialog.test.ts
@@ -6,11 +6,13 @@ import { ProcessEditor } from './page-objects/process-editor';
 import { FileExplorer } from './page-objects/explorer-view';
 import path from 'path';
 import { wait } from './utils/timeout';
+import { randomInt } from 'crypto';
 
 test.describe('Create User Dialog', () => {
   let page: Page;
   let explorer: FileExplorer;
   let processEditor: ProcessEditor;
+  let userDialogName: string;
   const projectName = 'prebuiltProject';
   const cleanUp = () => removeFromWorkspace(path.join(multiProjectWorkspacePath, projectName), 'src_hd');
 
@@ -20,6 +22,10 @@ test.describe('Create User Dialog', () => {
     explorer = new FileExplorer(page);
     await explorer.hasStatusMessage('Finished: Deploy Ivy Projects');
     processEditor = new ProcessEditor(page);
+  });
+
+  test.beforeEach(async () => {
+    userDialogName = 'hd' + randomInt(10_000).toString();
   });
 
   test.afterEach(async () => {
@@ -32,29 +38,27 @@ test.describe('Create User Dialog', () => {
   });
 
   test('Add Html Dialog', async () => {
-    const name = 'testHtmlDialog';
-    await explorer.addUserDialog(projectName, name, 'ch.ivyteam.test', 'Html Dialog');
-    await explorer.hasNode(`${name}.rddescriptor`);
-    await explorer.hasNode(`${name}.xhtml`);
-    await explorer.hasNode(`${name}Data.ivyClass`);
-    await explorer.hasNode(`${name}Process.p.json`);
-    await explorer.isTabWithNameVisible(name + '.xhtml');
+    await explorer.addUserDialog(projectName, userDialogName, 'ch.ivyteam.test', 'Html Dialog');
+    await explorer.hasNode(`${userDialogName}.rddescriptor`);
+    await explorer.hasNode(`${userDialogName}.xhtml`);
+    await explorer.hasNode(`${userDialogName}Data.ivyClass`);
+    await explorer.hasNode(`${userDialogName}Process.p.json`);
+    await explorer.isTabWithNameVisible(userDialogName + '.xhtml');
     await processEditor.activeEditorHasText('>Html Dialog</a>');
-    await explorer.doubleClickNode(`${name}Process.p.json`);
+    await explorer.doubleClickNode(`${userDialogName}Process.p.json`);
     const start = processEditor.locatorForElementType('g.start\\:htmlDialogStart');
     await expect(start).toBeVisible();
   });
 
   test('Add Offline Dialog', async () => {
-    const name = 'testOfflineDialog';
-    await explorer.addUserDialog(projectName, name, 'ch.ivyteam.test.offline', 'Offline Dialog');
-    await explorer.hasNode(`${name}.rddescriptor`);
-    await explorer.hasNode(`${name}.xhtml`);
-    await explorer.hasNode(`${name}Data.ivyClass`);
-    await explorer.hasNode(`${name}Process.p.json`);
-    await explorer.isTabWithNameVisible(name + '.xhtml');
+    await explorer.addUserDialog(projectName, userDialogName, 'ch.ivyteam.test.offline', 'Offline Dialog');
+    await explorer.hasNode(`${userDialogName}.rddescriptor`);
+    await explorer.hasNode(`${userDialogName}.xhtml`);
+    await explorer.hasNode(`${userDialogName}Data.ivyClass`);
+    await explorer.hasNode(`${userDialogName}Process.p.json`);
+    await explorer.isTabWithNameVisible(userDialogName + '.xhtml');
     await processEditor.activeEditorHasText('>Offline Html Dialog</a>');
-    await explorer.doubleClickNode(`${name}Process.p.json`);
+    await explorer.doubleClickNode(`${userDialogName}Process.p.json`);
     const start = processEditor.locatorForElementType('g.start\\:htmlDialogStart');
     await expect(start).toBeVisible();
   });

--- a/playwright/tests/create-user-dialog.test.ts
+++ b/playwright/tests/create-user-dialog.test.ts
@@ -39,6 +39,7 @@ test.describe('Create User Dialog', () => {
     await explorer.hasNode(`${name}Data.ivyClass`);
     await explorer.hasNode(`${name}Process.p.json`);
     await explorer.isTabWithNameVisible(name + '.xhtml');
+    await processEditor.activeEditorHasText('>Html Dialog</a>');
     await explorer.doubleClickNode(`${name}Process.p.json`);
     const start = processEditor.locatorForElementType('g.start\\:htmlDialogStart');
     await expect(start).toBeVisible();
@@ -52,6 +53,7 @@ test.describe('Create User Dialog', () => {
     await explorer.hasNode(`${name}Data.ivyClass`);
     await explorer.hasNode(`${name}Process.p.json`);
     await explorer.isTabWithNameVisible(name + '.xhtml');
+    await processEditor.activeEditorHasText('>Offline Html Dialog</a>');
     await explorer.doubleClickNode(`${name}Process.p.json`);
     const start = processEditor.locatorForElementType('g.start\\:htmlDialogStart');
     await expect(start).toBeVisible();

--- a/playwright/tests/fixtures/page.ts
+++ b/playwright/tests/fixtures/page.ts
@@ -21,7 +21,6 @@ export const test = base.extend<{ page: Page; pageFor(workspace: string): Promis
 });
 
 export async function pageFor(workspace: string, testTitle: string): Promise<Page> {
-  console.log('hello ****', process.env.RUN_IN_BRWOSER, runInBrowser);
   await close();
   if (runInBrowser) {
     return launchBrowser(workspace);

--- a/playwright/tests/fixtures/page.ts
+++ b/playwright/tests/fixtures/page.ts
@@ -56,5 +56,6 @@ async function launchBrowser(workspace: string): Promise<Page> {
 async function initialize(page: Page) {
   const pageObject = new PageObject(page);
   await pageObject.hasAnyStatusMessage();
+  await pageObject.saveAllFiles();
   await pageObject.closeAllTabs();
 }

--- a/playwright/tests/fixtures/page.ts
+++ b/playwright/tests/fixtures/page.ts
@@ -21,6 +21,7 @@ export const test = base.extend<{ page: Page; pageFor(workspace: string): Promis
 });
 
 export async function pageFor(workspace: string, testTitle: string): Promise<Page> {
+  console.log('hello ****', process.env.RUN_IN_BRWOSER, runInBrowser);
   await close();
   if (runInBrowser) {
     return launchBrowser(workspace);

--- a/playwright/tests/fixtures/page.ts
+++ b/playwright/tests/fixtures/page.ts
@@ -55,6 +55,6 @@ async function launchBrowser(workspace: string): Promise<Page> {
 
 async function initialize(page: Page) {
   const pageObject = new PageObject(page);
-  await pageObject.hasStatusMessage('Axon Ivy Extension activated');
+  await pageObject.hasAnyStatusMessage();
   await pageObject.closeAllTabs();
 }

--- a/playwright/tests/page-objects/editor.ts
+++ b/playwright/tests/page-objects/editor.ts
@@ -15,7 +15,7 @@ export class Editor extends View {
 
   async revertAndCloseEditor() {
     if (await this.tabLocator.isVisible()) {
-      await this.tabLocator.click();
+      await this.tabLocator.click({ delay: 500 });
       await this.executeCommand('View: Revert and Close Editor');
     }
     await expect(this.tabLocator).toBeHidden();

--- a/playwright/tests/page-objects/page-object.ts
+++ b/playwright/tests/page-objects/page-object.ts
@@ -26,6 +26,10 @@ export class PageObject {
     await expect(this.page.locator('#status\\.extensionMessage')).toHaveText(message, { timeout });
   }
 
+  async hasAnyStatusMessage() {
+    await expect(this.page.locator('#status\\.extensionMessage')).toBeVisible();
+  }
+
   async provideUserInput(input?: string) {
     if (input) {
       await this.quickInputBox().locator('input.input').fill(input);

--- a/playwright/tests/page-objects/page-object.ts
+++ b/playwright/tests/page-objects/page-object.ts
@@ -57,8 +57,14 @@ export class PageObject {
   }
 
   async saveAllFiles() {
-    await this.executeCommand('File: Save All Files');
-    await expect(this.page.locator('div.dirty')).toBeHidden();
+    const dirtyLocator = this.page.locator('div.dirty');
+    if (await dirtyLocator.isHidden()) {
+      return;
+    }
+    await expect(async () => {
+      this.executeCommand('File: Save All Files');
+      expect(await dirtyLocator.isHidden()).toBeTruthy();
+    }).toPass();
   }
 
   async activeEditorHasText(text: string) {

--- a/playwright/tests/page-objects/page-object.ts
+++ b/playwright/tests/page-objects/page-object.ts
@@ -10,7 +10,7 @@ export class PageObject {
     await this.quickInputBox()
       .locator('input.input')
       .fill('>' + command);
-    await this.page.locator(`.focused .quick-input-list-entry:has-text("${command}")`).click();
+    await this.page.locator(`.quick-input-list-entry:has-text("${command}")`).click();
     await expect(this.page.locator('.quick-input-list')).not.toBeVisible();
   }
 
@@ -50,5 +50,14 @@ export class PageObject {
 
   quickInputBox(): Locator {
     return this.page.locator('div.quick-input-box');
+  }
+
+  async saveAllFiles() {
+    await this.executeCommand('File: Save All Files');
+    await expect(this.page.locator('div.dirty')).toBeHidden();
+  }
+
+  async activeEditorHasText(text: string) {
+    await expect(this.page.locator('div.editor-container')).toContainText(text);
   }
 }

--- a/playwright/tests/page-objects/page-object.ts
+++ b/playwright/tests/page-objects/page-object.ts
@@ -62,7 +62,9 @@ export class PageObject {
       return;
     }
     await expect(async () => {
-      this.executeCommand('File: Save All Files');
+      if (await dirtyLocator.isVisible()) {
+        await this.executeCommand('File: Save All Files');
+      }
       expect(await dirtyLocator.isHidden()).toBeTruthy();
     }).toPass();
   }

--- a/playwright/tests/page-objects/page-object.ts
+++ b/playwright/tests/page-objects/page-object.ts
@@ -10,7 +10,7 @@ export class PageObject {
     await this.quickInputBox()
       .locator('input.input')
       .fill('>' + command);
-    await this.page.locator(`.quick-input-list-entry:has-text("${command}")`).click();
+    await this.page.locator(`.quick-input-list-entry:has-text("${command}")`).click({ force: true });
     await expect(this.page.locator('.quick-input-list')).not.toBeVisible();
   }
 

--- a/playwright/tests/page-objects/process-editor.ts
+++ b/playwright/tests/page-objects/process-editor.ts
@@ -58,6 +58,5 @@ export class ProcessEditor extends Editor {
     await activities.click();
     const newItemButton = this.viewFrameLoactor().locator('#activity-group').getByText(activityName, { exact: true });
     await newItemButton.click();
-    await this.saveAllFiles();
   }
 }

--- a/playwright/tests/page-objects/process-editor.ts
+++ b/playwright/tests/page-objects/process-editor.ts
@@ -51,7 +51,7 @@ export class ProcessEditor extends Editor {
     await expect(executedElement).toHaveClass(/executed/);
   }
 
-  async appendActivityAndSave(target: Locator, activityName: string) {
+  async appendActivity(target: Locator, activityName: string) {
     await target.click();
     await expect(target).toHaveClass(/selected/);
     const activities = this.viewFrameLoactor().getByTitle('Activities (A)');

--- a/playwright/tests/page-objects/process-editor.ts
+++ b/playwright/tests/page-objects/process-editor.ts
@@ -50,4 +50,14 @@ export class ProcessEditor extends Editor {
     await playButton.click();
     await expect(executedElement).toHaveClass(/executed/);
   }
+
+  async appendActivityAndSave(target: Locator, activityName: string) {
+    await target.click();
+    await expect(target).toHaveClass(/selected/);
+    const activities = this.viewFrameLoactor().getByTitle('Activities (A)');
+    await activities.click();
+    const newItemButton = this.viewFrameLoactor().locator('#activity-group').getByText(activityName, { exact: true });
+    await newItemButton.click();
+    await this.saveAllFiles();
+  }
 }

--- a/playwright/tests/page-objects/variables-editor.ts
+++ b/playwright/tests/page-objects/variables-editor.ts
@@ -33,11 +33,11 @@ export class VariablesEditor extends Editor {
   async add(key: string, value: string) {
     await this.clickButton('Add');
     const keyField = this.viewFrameLoactor().locator('vscode-text-field[grid-column="1"][current-value=""]');
-    await keyField.click({ delay: 100 });
+    await keyField.click({ delay: 300 });
     await this.typeText(key, 100);
 
     const valueField = this.viewFrameLoactor().locator('vscode-text-field[grid-column="2"][current-value=""]').locator('input');
-    await valueField.click({ delay: 100 });
+    await valueField.click({ delay: 300 });
     await this.typeText(value, 100);
   }
 

--- a/playwright/tests/process-outline.test.ts
+++ b/playwright/tests/process-outline.test.ts
@@ -21,7 +21,7 @@ test.describe('Process Outline', () => {
   });
 
   test.afterEach(async () => {
-    await processEditor.revertAndCloseEditor();
+    await processEditor.closeAllTabs();
   });
 
   test('Verify that Process Outline Explorer lists several elements', async () => {
@@ -35,7 +35,7 @@ test.describe('Process Outline', () => {
     await explorer.hasNoNode('unknown');
     await explorer.hasNoNode('Accept Request');
 
-    await processEditor.revertAndCloseEditor();
+    await processEditor.closeAllTabs();
     await explorer.hasNoNode('start.ivp');
     await explorer.closeView();
   });

--- a/playwright/tests/utils/app.ts
+++ b/playwright/tests/utils/app.ts
@@ -14,7 +14,7 @@ const args = [
 
 export async function launchElectronApp(workspacePath: string, testTitle: string): Promise<ElectronApplication> {
   return await _electron.launch({
-    executablePath: await downloadAndUnzipVSCode('insiders'),
+    executablePath: await downloadAndUnzipVSCode('stable'),
     args: [...args, workspacePath],
     recordVideo: {
       dir: path.join(__dirname, '..', '..', 'playwright-videos', testTitle.replaceAll(' ', '_'))

--- a/playwright/tests/utils/app.ts
+++ b/playwright/tests/utils/app.ts
@@ -1,6 +1,7 @@
 import { ElectronApplication, _electron } from '@playwright/test';
 import { downloadAndUnzipVSCode } from '@vscode/test-electron';
 import * as path from 'path';
+import { downloadVersion } from './download-vscode';
 
 const args = [
   '--disable-updates',
@@ -14,7 +15,7 @@ const args = [
 
 export async function launchElectronApp(workspacePath: string, testTitle: string): Promise<ElectronApplication> {
   return await _electron.launch({
-    executablePath: await downloadAndUnzipVSCode('stable'),
+    executablePath: await downloadAndUnzipVSCode(downloadVersion),
     args: [...args, workspacePath],
     recordVideo: {
       dir: path.join(__dirname, '..', '..', 'playwright-videos', testTitle.replaceAll(' ', '_'))

--- a/playwright/tests/utils/app.ts
+++ b/playwright/tests/utils/app.ts
@@ -1,7 +1,7 @@
 import { ElectronApplication, _electron } from '@playwright/test';
 import { downloadAndUnzipVSCode } from '@vscode/test-electron';
 import * as path from 'path';
-import { downloadVersion } from './download-vscode';
+import { downloadVersion } from './download-version';
 
 const args = [
   '--disable-updates',

--- a/playwright/tests/utils/download-version.ts
+++ b/playwright/tests/utils/download-version.ts
@@ -1,0 +1,3 @@
+import { DownloadVersion } from '@vscode/test-electron/out/download';
+
+export const downloadVersion: DownloadVersion = process.env.CI || process.env.RUN_STABLE_VERSION ? 'stable' : 'insiders';

--- a/playwright/tests/utils/download-vscode.ts
+++ b/playwright/tests/utils/download-vscode.ts
@@ -1,3 +1,6 @@
 import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+import { DownloadVersion } from '@vscode/test-electron/out/download';
 
-downloadAndUnzipVSCode('stable');
+export const downloadVersion: DownloadVersion = process.env.CI || process.env.RUN_STABLE_VERSION ? 'stable' : 'insiders';
+
+downloadAndUnzipVSCode(downloadVersion);

--- a/playwright/tests/utils/download-vscode.ts
+++ b/playwright/tests/utils/download-vscode.ts
@@ -1,6 +1,4 @@
 import { downloadAndUnzipVSCode } from '@vscode/test-electron';
-import { DownloadVersion } from '@vscode/test-electron/out/download';
-
-export const downloadVersion: DownloadVersion = process.env.CI || process.env.RUN_STABLE_VERSION ? 'stable' : 'insiders';
+import { downloadVersion } from './download-version';
 
 downloadAndUnzipVSCode(downloadVersion);

--- a/playwright/tests/utils/download-vscode.ts
+++ b/playwright/tests/utils/download-vscode.ts
@@ -1,3 +1,3 @@
 import { downloadAndUnzipVSCode } from '@vscode/test-electron';
 
-downloadAndUnzipVSCode('insiders');
+downloadAndUnzipVSCode('stable');

--- a/playwright/tests/utils/timeout.ts
+++ b/playwright/tests/utils/timeout.ts
@@ -1,4 +1,4 @@
 import { Page } from '@playwright/test';
 
-const timeout = process.env.CI ? 5_000 : 0;
+const timeout = process.env.CI ? 1_000 : 0;
 export const wait = async (page: Page) => await page.waitForTimeout(timeout);

--- a/playwright/tests/utils/timeout.ts
+++ b/playwright/tests/utils/timeout.ts
@@ -1,4 +1,4 @@
 import { Page } from '@playwright/test';
 
-const timeout = process.env.CI ? 1_000 : 0;
+const timeout = process.env.CI ? 5_000 : 0;
 export const wait = async (page: Page) => await page.waitForTimeout(timeout);


### PR DESCRIPTION
- run tests against vscode stable during CI. it doesn't seem to be possible to run against vscode stable locally when another vscode instance is open, so I test against vscode insiders locally.
- create processes and hds with random names to increase the chances of a retry
- add test: Assert that process gets redeployed after editing