### PR TITLE
XIVY-12913: Improve open-page action + playwright tests

### DIFF
--- a/playwright/tests/page-objects/inscription-view.ts
+++ b/playwright/tests/page-objects/inscription-view.ts
@@ -22,6 +22,11 @@ export class InscriptionView extends PageObject {
     return this.parent.getByLabel(label, { exact: true });
   }
 
+  cellInsideTable(tableCount: number, cellCount: number): Locator {
+    const firstTable = this.parent.getByRole('table').nth(tableCount);
+    return firstTable.getByRole('cell').nth(cellCount);
+  }
+
   async clickButton(label: string) {
     await this.parent.getByRole('button', { name: label }).click();
   }


### PR DESCRIPTION
I have improved the openPage action. Now it's also possible to simply enter the relative path of a file within the project itself and open it (similar behavior to the old Inscription view). 

I've written two Playwright tests for the openPage-Action:
- One checks if a file is opened (using breadcrumbs). It's a bit of a hack but the quickest way I've found to check the active file.
- The other test verifies if a specific URL is opened in the integrated browser.

Note: Attempting to open external URLs in the integrated browser is blocked. You can still open them through the button on the topright in the integrated browser. The help pages work and can be opened in the integrated browser, which is the most important aspect.

![example3_pageOpen](https://github.com/axonivy/vscode-extensions/assets/141223521/6dc5b556-04fc-4b47-8cb2-db8fe08e792f)