### PR TITLE
Fix code scanning alert no. 2: Client-side cross-site scripting

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -35,7 +35,8 @@
     "vscode-messenger": "^0.4.5",
     "vscode-messenger-common": "^0.4.5",
     "vscode-ws-jsonrpc": "^3.0.0",
-    "ws": "^8.16.0"
+    "ws": "^8.16.0",
+    "dompurify": "^3.2.3"
   },
   "devDependencies": {
     "@types/vscode": "^1.85.0",

--- a/extension/src/browser/media/index.js
+++ b/extension/src/browser/media/index.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-undef
 const vscode = acquireVsCodeApi();
+import DOMPurify from 'dompurify';
 
 function onceDocumentLoaded(func) {
   if (document.readyState === 'loading' || document.readyState === 'uninitialized') {
@@ -72,8 +73,9 @@ onceDocumentLoaded(() => {
   });
 
   function navigateTo(rawUrl) {
+    const sanitizedUrl = DOMPurify.sanitize(rawUrl);
     try {
-      const url = new URL(rawUrl);
+      const url = new URL(sanitizedUrl);
 
       // Try to bust the cache for the iframe
       // There does not appear to be any way to reliably do this except modifying the url
@@ -81,10 +83,10 @@ onceDocumentLoaded(() => {
 
       iframe.src = url.toString();
     } catch {
-      iframe.src = rawUrl;
+      iframe.src = sanitizedUrl;
     }
 
-    vscode.setState({ url: rawUrl });
+    vscode.setState({ url: sanitizedUrl });
   }
 });
 


### PR DESCRIPTION
Fixes [https://github.com/axonivy/vscode-extensions/security/code-scanning/2](https://github.com/axonivy/vscode-extensions/security/code-scanning/2)

To fix the problem, we need to sanitize the user input before using it to set the `src` attribute of the iframe. This can be done by using a library like `DOMPurify` to clean the input and ensure it does not contain any malicious content.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the file.
3. Use `DOMPurify` to sanitize the `rawUrl` before using it in the `navigateTo` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
