### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -34,7 +34,8 @@
     "vscode-messenger": "^0.4.5",
     "vscode-messenger-common": "^0.4.5",
     "vscode-ws-jsonrpc": "^3.0.0",
-    "ws": "^8.16.0"
+    "ws": "^8.16.0",
+    "dompurify": "^3.2.4"
   },
   "devDependencies": {
     "@types/vscode": "^1.85.0",

--- a/extension/src/browser/media/index.js
+++ b/extension/src/browser/media/index.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-undef
 const vscode = acquireVsCodeApi();
+const DOMPurify = require('dompurify');
 
 function onceDocumentLoaded(func) {
   if (document.readyState === 'loading' || document.readyState === 'uninitialized') {
@@ -81,7 +82,7 @@ onceDocumentLoaded(() => {
 
       iframe.src = url.toString();
     } catch {
-      iframe.src = rawUrl;
+      iframe.src = DOMPurify.sanitize(rawUrl);
     }
 
     vscode.setState({ url: rawUrl });


### PR DESCRIPTION
Potential fix for [https://github.com/axonivy/vscode-extensions/security/code-scanning/3](https://github.com/axonivy/vscode-extensions/security/code-scanning/3)

To fix the problem, we need to ensure that the user input is properly sanitized before it is used to set the `src` attribute of the iframe. This can be achieved by using a library like `DOMPurify` to sanitize the input URL. 

1. Import the `DOMPurify` library.
2. Use `DOMPurify.sanitize` to sanitize the `rawUrl` before assigning it to the iframe `src` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
