### PR TITLE
XIVY-16200 integrate cms editor

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -60,6 +60,15 @@
         ]
       },
       {
+        "viewType": "ivy.cmsEditor",
+        "displayName": "Axon Ivy CMS Editor",
+        "selector": [
+          {
+            "filenamePattern": "cms_*.yaml"
+          }
+        ]
+      },
+      {
         "viewType": "ivy.glspDiagram",
         "displayName": "Axon Ivy Process Editor",
         "selector": [
@@ -93,6 +102,11 @@
         "title": "Create a new Variables file",
         "category": "Ivy Variables Editor",
         "icon": "$(add)"
+      },
+      {
+        "command": "ivyBrowserView.openCmsEditor",
+        "title": "Open CMS Editor",
+        "category": "Axon Ivy"
       },
       {
         "command": "ivyBrowserView.openDevWfUi",

--- a/extension/src/base/commands.ts
+++ b/extension/src/base/commands.ts
@@ -45,4 +45,5 @@ type ViewCommand =
   | 'ivyBrowserView.open'
   | 'ivyBrowserView.openDevWfUi'
   | 'ivyBrowserView.openEngineCockpit'
-  | 'ivyBrowserView.openNEO';
+  | 'ivyBrowserView.openNEO'
+  | 'ivyBrowserView.openCmsEditor';

--- a/extension/src/editors/cms-editor/cms-editor-provider.ts
+++ b/extension/src/editors/cms-editor/cms-editor-provider.ts
@@ -1,0 +1,26 @@
+import * as vscode from 'vscode';
+import { messenger } from '../..';
+import { createWebViewContent } from '../webview-helper';
+import { registerOpenCmsEditorCmd } from './open-cms-editor-cmd';
+import { setupCommunication } from './webview-communication';
+
+export class CmsEditorProvider implements vscode.CustomTextEditorProvider {
+  static readonly viewType = 'ivy.cmsEditor';
+
+  private constructor(
+    readonly context: vscode.ExtensionContext,
+    readonly websocketUrl: URL
+  ) {}
+
+  static register(context: vscode.ExtensionContext, websocketUrl: URL) {
+    registerOpenCmsEditorCmd(context, websocketUrl);
+    const provider = new CmsEditorProvider(context, websocketUrl);
+    return vscode.window.registerCustomEditorProvider(CmsEditorProvider.viewType, provider);
+  }
+
+  resolveCustomTextEditor(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel) {
+    setupCommunication(this.websocketUrl, messenger, webviewPanel, document);
+    webviewPanel.webview.options = { enableScripts: true };
+    webviewPanel.webview.html = createWebViewContent(this.context, webviewPanel.webview, 'cms-editor');
+  }
+}

--- a/extension/src/editors/cms-editor/open-cms-editor-cmd.ts
+++ b/extension/src/editors/cms-editor/open-cms-editor-cmd.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode';
+import { messenger } from '../..';
+import { registerCommand } from '../../base/commands';
+import { createWebViewContent } from '../webview-helper';
+import { setupCommunication } from './webview-communication';
+
+export const registerOpenCmsEditorCmd = (context: vscode.ExtensionContext, websocketUrl: URL) => {
+  registerCommand('ivyBrowserView.openCmsEditor', context, () => {
+    const webviewPanel = vscode.window.createWebviewPanel('cms-editor', 'CMS', vscode.ViewColumn.One, { enableScripts: true });
+    setupCommunication(websocketUrl, messenger, webviewPanel);
+    webviewPanel.webview.html = createWebViewContent(context, webviewPanel.webview, 'cms-editor');
+  });
+};

--- a/extension/src/editors/cms-editor/webview-communication.ts
+++ b/extension/src/editors/cms-editor/webview-communication.ts
@@ -1,0 +1,44 @@
+import type { CmsActionArgs } from '@axonivy/cms-editor-protocol';
+import { DisposableCollection } from '@eclipse-glsp/vscode-integration';
+import * as vscode from 'vscode';
+import { Messenger } from 'vscode-messenger';
+import { MessageParticipant, NotificationType } from 'vscode-messenger-common';
+import { IvyBrowserViewProvider } from '../../browser/ivy-browser-view-provider';
+import { InitializeConnectionRequest, isAction, WebviewReadyNotification } from '../notification-helper';
+import { WebSocketForwarder } from '../websocket-forwarder';
+
+const ConfigWebSocketMessage: NotificationType<unknown> = { method: 'cmsWebSocketMessage' };
+
+export const setupCommunication = (
+  websocketUrl: URL,
+  messenger: Messenger,
+  webviewPanel: vscode.WebviewPanel,
+  document?: vscode.TextDocument
+) => {
+  const messageParticipant = messenger.registerWebviewPanel(webviewPanel);
+  const toDispose = new DisposableCollection(
+    new CmsEditorWebSocketForwarder(websocketUrl, messenger, messageParticipant),
+    messenger.onNotification(
+      WebviewReadyNotification,
+      () =>
+        messenger.sendNotification(InitializeConnectionRequest, messageParticipant, {
+          file: document?.fileName ?? vscode.workspace.workspaceFolders?.[0].uri.path
+        }),
+      { sender: messageParticipant }
+    )
+  );
+  webviewPanel.onDidDispose(() => toDispose.dispose());
+};
+
+class CmsEditorWebSocketForwarder extends WebSocketForwarder {
+  constructor(websocketUrl: URL, messenger: Messenger, messageParticipant: MessageParticipant) {
+    super(websocketUrl, 'ivy-cms-lsp', messenger, messageParticipant, ConfigWebSocketMessage);
+  }
+
+  protected override handleClientMessage(message: unknown) {
+    if (isAction<CmsActionArgs>(message) && message.params.actionId === 'openUrl') {
+      IvyBrowserViewProvider.instance.open(message.params.payload);
+    }
+    super.handleClientMessage(message);
+  }
+}

--- a/extension/src/editors/websocket-forwarder.ts
+++ b/extension/src/editors/websocket-forwarder.ts
@@ -4,13 +4,15 @@ import vscode from 'vscode';
 import { NotificationType, MessageParticipant } from 'vscode-messenger-common';
 import { Messenger } from 'vscode-messenger';
 
+type Endpoint = 'ivy-inscription-lsp' | 'ivy-script-lsp' | 'ivy-form-lsp' | 'ivy-variables-lsp' | 'ivy-data-class-lsp' | 'ivy-cms-lsp';
+
 export class WebSocketForwarder implements vscode.Disposable {
   readonly toDispose = new DisposableCollection();
   readonly webSocket: WebSocket;
 
   constructor(
     readonly websocketUrl: URL,
-    readonly websocketEndpoint: 'ivy-inscription-lsp' | 'ivy-script-lsp' | 'ivy-form-lsp' | 'ivy-variables-lsp' | 'ivy-data-class-lsp',
+    readonly websocketEndpoint: Endpoint,
     readonly messenger: Messenger,
     readonly messageParticipant: MessageParticipant,
     readonly notificationType: NotificationType<unknown>

--- a/extension/src/engine/engine-manager.ts
+++ b/extension/src/engine/engine-manager.ts
@@ -16,6 +16,7 @@ import { setStatusBarMessage } from '../base/status-bar';
 import { DataClassInit, NewProjectParams } from './api/generated/client';
 import { WebSocketClientProvider } from './ws-client';
 import DataClassEditorProvider from '../editors/dataclass-editor/dataclass-editor-provider';
+import { CmsEditorProvider } from '../editors/cms-editor/cms-editor-provider';
 
 export class IvyEngineManager {
   private static _instance: IvyEngineManager;
@@ -53,6 +54,7 @@ export class IvyEngineManager {
     ProcessEditorProvider.register(this.context, websocketUrl);
     FormEditorProvider.register(this.context, websocketUrl);
     VariableEditorProvider.register(this.context, websocketUrl);
+    CmsEditorProvider.register(this.context, websocketUrl);
     DataClassEditorProvider.register(this.context, websocketUrl);
     WebSocketClientProvider(websocketUrl);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "playwright/"
       ],
       "dependencies": {
+        "@axonivy/cms-editor": "13.1.0-next.76",
         "@axonivy/dataclass-editor": "13.1.0-next.497",
         "@axonivy/form-editor": "13.1.0-next.632",
         "@axonivy/form-editor-core": "13.1.0-next.632",
@@ -185,6 +186,30 @@
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
+    },
+    "node_modules/@axonivy/cms-editor": {
+      "version": "13.1.0-next.76",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/cms-editor/-/cms-editor-13.1.0-next.76.tgz",
+      "integrity": "sha512-JwWvlbhYZnUQDAtyebmaPvJJ3d8Jimd/6xaYshhFnZrsoAVd34TGhgfnmXkOa4ESokKXmPgRdx2rJDKkDjsCAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@axonivy/cms-editor-protocol": "13.1.0-next.76+d6d97a0",
+        "@tanstack/react-virtual": "^3.12.0"
+      },
+      "peerDependencies": {
+        "@axonivy/jsonrpc": "~13.1.0-next",
+        "@axonivy/ui-components": "~13.1.0-next",
+        "@axonivy/ui-icons": "~13.1.0-next",
+        "@tanstack/react-query": "^5.64",
+        "@tanstack/react-query-devtools": "^5.64",
+        "react": "^18.2 || ^19.0"
+      }
+    },
+    "node_modules/@axonivy/cms-editor-protocol": {
+      "version": "13.1.0-next.76",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/cms-editor-protocol/-/cms-editor-protocol-13.1.0-next.76.tgz",
+      "integrity": "sha512-7iGsVylTNA6PHoQ+qKV2ZIXXoV8ZdfNKa3Pof39DGLVslfJ3iFWXgfXAGGY2WO8NRBXvstyj5bBfFZyArIfKRg==",
+      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)"
     },
     "node_modules/@axonivy/dataclass-editor": {
       "version": "13.1.0-next.497",
@@ -20622,6 +20647,10 @@
       "resolved": "webviews/browser",
       "link": true
     },
+    "node_modules/vscode-cms-editor-webview": {
+      "resolved": "webviews/cms-editor",
+      "link": true
+    },
     "node_modules/vscode-config-editor-webview": {
       "resolved": "webviews/config-editor",
       "link": true
@@ -21490,6 +21519,13 @@
       "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
       "dependencies": {
         "dompurify": "^3.2.4",
+        "vscode-webview-common": "13.1.0"
+      }
+    },
+    "webviews/cms-editor": {
+      "name": "vscode-cms-editor-webview",
+      "version": "13.1.0",
+      "dependencies": {
         "vscode-webview-common": "13.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@axonivy/process-editor": "13.1.0-next.1437",
     "@axonivy/process-editor-inscription": "13.1.0-next.1437",
     "@axonivy/variable-editor": "13.1.0-next.647",
+    "@axonivy/cms-editor": "13.1.0-next.76",
     "vscode-messenger-common": "0.4.5"
   },
   "devDependencies": {

--- a/playwright/tests/cms-editor.spec.ts
+++ b/playwright/tests/cms-editor.spec.ts
@@ -11,19 +11,14 @@ test('Open by command', async ({ page }) => {
   await editor.hasContentObject('/contentObject');
 });
 
-test('Open by file', async ({ page }) => {
+test('Open by file and open help', async ({ page }) => {
   const editor = new CmsEditor(page);
   await editor.hasDeployProjectStatusMessage();
   await editor.openEditorFile();
   await editor.isTabVisible();
   await editor.isViewVisible();
   await editor.hasContentObject('/contentObject');
-});
 
-test('Open help', async ({ page }) => {
-  const editor = new CmsEditor(page);
-  await editor.hasDeployProjectStatusMessage();
-  await editor.openEditorFile();
   await editor.help.click();
   const browserView = new BrowserView(page);
   expect((await browserView.input().inputValue()).toString()).toMatch(/^https:\/\/developer\.axonivy\.com.*cms\/index.html$/);

--- a/playwright/tests/cms-editor.spec.ts
+++ b/playwright/tests/cms-editor.spec.ts
@@ -1,0 +1,30 @@
+import { expect } from 'playwright/test';
+import { test } from './fixtures/baseTest';
+import { BrowserView } from './page-objects/browser-view';
+import { CmsEditor } from './page-objects/cms-editor';
+
+test('Open by command', async ({ page }) => {
+  const editor = new CmsEditor(page);
+  await editor.hasDeployProjectStatusMessage();
+  await editor.executeCommand('Axon Ivy: Open CMS Editor');
+  await editor.isViewVisible();
+  await editor.hasContentObject('/contentObject');
+});
+
+test('Open by file', async ({ page }) => {
+  const editor = new CmsEditor(page);
+  await editor.hasDeployProjectStatusMessage();
+  await editor.openEditorFile();
+  await editor.isTabVisible();
+  await editor.isViewVisible();
+  await editor.hasContentObject('/contentObject');
+});
+
+test('Open help', async ({ page }) => {
+  const editor = new CmsEditor(page);
+  await editor.hasDeployProjectStatusMessage();
+  await editor.openEditorFile();
+  await editor.help.click();
+  const browserView = new BrowserView(page);
+  expect((await browserView.input().inputValue()).toString()).toMatch(/^https:\/\/developer\.axonivy\.com.*cms\/index.html$/);
+});

--- a/playwright/tests/page-objects/cms-editor.ts
+++ b/playwright/tests/page-objects/cms-editor.ts
@@ -1,0 +1,22 @@
+import { expect, Locator, Page } from '@playwright/test';
+import { Editor } from './editor';
+
+export class CmsEditor extends Editor {
+  readonly toolbar: Locator;
+  readonly help: Locator;
+
+  constructor(page: Page, editorFile = 'cms_en.yaml') {
+    super(editorFile, page);
+    this.toolbar = this.viewFrameLoactor().locator('.cms-editor-main-toolbar');
+    this.help = this.viewFrameLoactor().getByRole('button', { name: /Help/ });
+  }
+
+  override async isViewVisible() {
+    await expect(this.toolbar).toContainText('CMS -');
+  }
+
+  async hasContentObject(contentObject: string) {
+    const field = this.viewFrameLoactor().locator('td > span');
+    await expect(field).toHaveText(contentObject);
+  }
+}

--- a/playwright/tests/workspaces/prebuiltProject/cms/cms_de.yaml
+++ b/playwright/tests/workspaces/prebuiltProject/cms/cms_de.yaml
@@ -1,0 +1,1 @@
+contentObject: wert

--- a/playwright/tests/workspaces/prebuiltProject/cms/cms_en.yaml
+++ b/playwright/tests/workspaces/prebuiltProject/cms/cms_en.yaml
@@ -1,0 +1,1 @@
+contentObject: value

--- a/vscode-extensions.code-workspace
+++ b/vscode-extensions.code-workspace
@@ -17,6 +17,10 @@
       "path": "webviews/config-editor"
     },
     {
+      "name": "webview/cms-editor",
+      "path": "webviews/cms-editor"
+    },
+    {
       "name": "webview/process-editor",
       "path": "webviews/process-editor"
     },

--- a/webviews/cms-editor/index.html
+++ b/webviews/cms-editor/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CMS</title>
+  </head>
+
+  <body id="webview-body">
+    <div id="root" style="height: 100%"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/webviews/cms-editor/package.json
+++ b/webviews/cms-editor/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "vscode-cms-editor-webview",
+  "version": "13.1.0",
+  "private": true,
+  "dependencies": {
+    "vscode-webview-common": "13.1.0"
+  },
+  "type": "module",
+  "scripts": {
+    "build": "vite build --mode development --emptyOutDir",
+    "build:production": "vite build --emptyOutDir",
+    "clean": "rimraf dist lib",
+    "type": "tsc --noEmit",
+    "watch": "vite build --mode development --watch --emptyOutDir"
+  }
+}

--- a/webviews/cms-editor/src/index.tsx
+++ b/webviews/cms-editor/src/index.tsx
@@ -1,0 +1,31 @@
+import { ClientContextProvider, ClientJsonRpc, CmsEditor, initQueryClient, QueryProvider } from '@axonivy/cms-editor';
+import '@axonivy/cms-editor/lib/editor.css';
+import * as React from 'react';
+import { createRoot } from 'react-dom/client';
+import { Messenger, VsCodeApi } from 'vscode-messenger-webview';
+import { InitializeConnection, initMessenger, toConnection } from 'vscode-webview-common';
+import 'vscode-webview-common/css/colors.css';
+
+declare function acquireVsCodeApi(): VsCodeApi;
+const messenger = new Messenger(acquireVsCodeApi());
+
+export async function start({ file }: InitializeConnection) {
+  const connection = toConnection(messenger, 'cmsWebSocketMessage');
+  const client = await ClientJsonRpc.startClient(connection);
+  const queryClient = initQueryClient();
+  const rootElement = document.getElementById('root');
+  if (!rootElement) {
+    throw new Error('Root element not found');
+  }
+  createRoot(rootElement).render(
+    <React.StrictMode>
+      <ClientContextProvider client={client}>
+        <QueryProvider client={queryClient}>
+          <CmsEditor context={{ app: '', pmv: '', file }} />
+        </QueryProvider>
+      </ClientContextProvider>
+    </React.StrictMode>
+  );
+}
+
+initMessenger(messenger, start);

--- a/webviews/cms-editor/tsconfig.json
+++ b/webviews/cms-editor/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/webviews/cms-editor/vite.config.ts
+++ b/webviews/cms-editor/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig(() => {
+  const config = {
+    plugins: [tsconfigPaths()],
+    build: {
+      manifest: 'build.manifest.json',
+      outDir: '../../extension/dist/webviews/cms-editor',
+      chunkSizeWarningLimit: 5000
+    },
+    server: {
+      port: 3003,
+      open: false
+    },
+    base: './'
+  };
+  return config;
+});

--- a/webviews/webview-common/src/connection.ts
+++ b/webviews/webview-common/src/connection.ts
@@ -15,6 +15,7 @@ export const initMessenger = (messenger: Messenger, start: (init: InitializeConn
 
 type Method =
   | 'configWebSocketMessage'
+  | 'cmsWebSocketMessage'
   | 'dataclassWebSocketMessage'
   | 'formWebSocketMessage'
   | 'inscriptionWebSocketMessage'


### PR DESCRIPTION
The CMS Editor can be opened by opening any `cms_*.yaml` or executing the command `Axon Ivy: Open CMS Editor`.
The command currently simply opens the CMS Editor for the first project in the workspace.
