### PR TITLE
Initial support for diagram diffing

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -49,6 +49,11 @@
     "onStartupFinished"
   ],
   "contributes": {
+    "configurationDefaults": {
+      "workbench.editorAssociations": {
+        "{git,gitlens}:/**/*.p.json": "default"
+      }
+    },
     "customEditors": [
       {
         "viewType": "ivy.variableEditor",
@@ -74,6 +79,9 @@
         "selector": [
           {
             "filenamePattern": "*.p.json"
+          },
+          {
+            "filenamePattern": "*.pdiff"
           }
         ]
       },
@@ -268,6 +276,13 @@
         "command": "engine.deactivateAnimation",
         "title": "Deactivate Process Animation",
         "category": "Axon Ivy"
+      },
+      {
+        "command": "ivy.glspDiagram.diff",
+        "title": "Compare with Proces Diagram Editor",
+        "category": "Axon Ivy",
+        "icon": "$(diff)",
+        "enablement": "resourceFilename =~ /.*\\.p\\.json$/ && activeEditor == workbench.editors.textDiffEditor"
       }
     ],
     "configuration": [
@@ -387,6 +402,11 @@
         {
           "submenu": "workflow.editor.title",
           "group": "bookmarks"
+        },
+        {
+          "command": "ivy.glspDiagram.diff",
+          "when": "resourceFilename =~ /.*\\.p\\.json$/ && activeEditor == workbench.editors.textDiffEditor",
+          "group": "navigation"
         }
       ],
       "workflow.editor.title": [

--- a/extension/src/editors/process-editor/diagram-diff.ts
+++ b/extension/src/editors/process-editor/diagram-diff.ts
@@ -1,0 +1,51 @@
+import * as vscode from 'vscode';
+
+export const DIAGRAM_DIFF_EXTENSION = '.pdiff';
+
+let diffIdCounter = 0;
+export function configureDiagramDiffCommand(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ivy.glspDiagram.diff', () => {
+      const diffId = `pdiff-${diffIdCounter++}`;
+      const activeTab = vscode.window.tabGroups.activeTabGroup?.activeTab;
+      if (activeTab?.input instanceof vscode.TabInputTextDiff) {
+        const leftDiff: DiagramDiff = { diffId, side: 'left', uri: activeTab.input.original };
+        const rightDiff: DiagramDiff = { diffId, side: 'right', uri: activeTab.input.modified };
+        const leftUri = toDiagramDiffUri(leftDiff);
+        const rightUri = toDiagramDiffUri(rightDiff);
+        vscode.commands.executeCommand('vscode.diff', leftUri, rightUri, activeTab.label);
+      }
+    })
+  );
+}
+
+export interface DiagramDiff {
+  diffId: string;
+  side: 'left' | 'right';
+  uri: vscode.Uri;
+}
+
+export function getDiagramDiffFromUri(uri: vscode.Uri): DiagramDiff | undefined {
+  const queryParams = new URLSearchParams(uri.query);
+  const diffId = queryParams.get('diffId');
+  const side = queryParams.get('side') as 'left' | 'right' | null;
+  const uriString = queryParams.get('uri');
+  if (diffId && side && uriString) {
+    const decodedUriStr = decodeURIComponent(uriString);
+    const decodedUri = vscode.Uri.parse(decodedUriStr);
+    return {
+      diffId,
+      side,
+      uri: decodedUri
+    };
+  }
+  return undefined;
+}
+
+export function toDiagramDiffUri(diff: DiagramDiff): vscode.Uri {
+  const queryParams = new URLSearchParams();
+  queryParams.append('diffId', diff.diffId);
+  queryParams.append('side', diff.side);
+  queryParams.append('uri', diff.uri.toString());
+  return vscode.Uri.from({ scheme: 'file', path: `${diff.side}.pdiff`, query: queryParams.toString() });
+}

--- a/extension/src/editors/process-editor/process-editor-provider.ts
+++ b/extension/src/editors/process-editor/process-editor-provider.ts
@@ -3,13 +3,24 @@ import {
   GlspEditorProvider,
   SocketGlspVscodeServer,
   Writable,
-  configureDefaultCommands
+  configureDefaultCommands,
+  WebviewEndpoint,
+  GLSPDiagramIdentifier
 } from '@eclipse-glsp/vscode-integration';
 import * as vscode from 'vscode';
 import { setupCommunication } from './webview-communication';
 import { createWebViewContent } from '../webview-helper';
 import { ProcessVscodeConnector } from './process-vscode-connector';
 import { messenger } from '../..';
+import { configureDiagramDiffCommand, DIAGRAM_DIFF_EXTENSION, getDiagramDiffFromUri } from './diagram-diff';
+
+interface ProcessEditorDiagramIdentifier extends GLSPDiagramIdentifier {
+  diff?: {
+    id: string;
+    side: 'left' | 'right';
+    content: string;
+  };
+}
 
 export default class ProcessEditorProvider extends GlspEditorProvider {
   diagramType = 'ivy-glsp-process';
@@ -21,6 +32,49 @@ export default class ProcessEditorProvider extends GlspEditorProvider {
     readonly websocketUrl: URL
   ) {
     super(glspVscodeConnector);
+  }
+
+  private webViewCount = 0;
+  override async resolveCustomEditor(
+    document: vscode.CustomDocument,
+    webviewPanel: vscode.WebviewPanel,
+    token: vscode.CancellationToken
+  ): Promise<void> {
+    // This is used to initialize GLSP for our diagram
+    const diagramIdentifier: ProcessEditorDiagramIdentifier = {
+      diagramType: this.diagramType,
+      uri: serializeUri(document.uri),
+      clientId: `${this.diagramType}_${this.webViewCount++}`
+    };
+
+    if (document.uri.path.endsWith(DIAGRAM_DIFF_EXTENSION)) {
+      const diff = getDiagramDiffFromUri(document.uri);
+      if (!diff) {
+        throw new Error(`Invalid diff URI: ${document.uri}`);
+      }
+      const contentBuffer = await vscode.workspace.fs.readFile(diff.uri);
+      const content = new TextDecoder().decode(contentBuffer);
+      diagramIdentifier.diff = {
+        id: diff.diffId,
+        side: diff.side,
+        content: content
+      };
+      // Set the URI to the original file for now, so that the editor does not break
+      // unitl the server propely handles the diff
+      diagramIdentifier.uri = 'file://' + diff.uri.path;
+    }
+
+    const endpoint = new WebviewEndpoint({ diagramIdentifier, messenger: this.glspVscodeConnector.messenger, webviewPanel });
+
+    // Register document/diagram panel/model in vscode connector
+    this.glspVscodeConnector.registerClient({
+      clientId: diagramIdentifier.clientId,
+      diagramType: diagramIdentifier.diagramType,
+      document: document,
+      webviewEndpoint: endpoint
+    });
+
+    this.setUpWebview(document, webviewPanel, token, diagramIdentifier.clientId);
   }
 
   async setUpWebview(
@@ -36,6 +90,7 @@ export default class ProcessEditorProvider extends GlspEditorProvider {
   }
 
   static register(context: vscode.ExtensionContext, websocketUrl: URL) {
+    configureDiagramDiffCommand(context);
     const workflowServer = new SocketGlspVscodeServer({
       clientId: 'ivy-glsp-web-ide-process-editor',
       clientName: 'ivy-glsp-web-ide-process-editor',
@@ -66,4 +121,13 @@ export default class ProcessEditorProvider extends GlspEditorProvider {
 
     configureDefaultCommands({ extensionContext: context, connector: ivyVscodeConnector, diagramPrefix: 'workflow' });
   }
+}
+
+function serializeUri(uri: vscode.Uri): string {
+  let uriString = uri.toString();
+  const match = uriString.match(/file:\/\/\/([a-z])%3A/i);
+  if (match) {
+    uriString = 'file:///' + match[1] + ':' + uriString.substring(match[0].length);
+  }
+  return uriString;
 }

--- a/webviews/process-editor/src/ivy-diagram-widget.ts
+++ b/webviews/process-editor/src/ivy-diagram-widget.ts
@@ -1,0 +1,22 @@
+import { DiagramLoadingOptions, Args } from '@eclipse-glsp/client';
+import { GLSPDiagramIdentifier, GLSPDiagramWidget } from '@eclipse-glsp/vscode-integration-webview';
+import { inject, injectable } from 'inversify';
+import type { ProcessEditorDiagramIdentifier } from './app';
+
+@injectable()
+export class IvyDiagramWidget extends GLSPDiagramWidget {
+  @inject(GLSPDiagramIdentifier)
+  protected diagramIdentifier: ProcessEditorDiagramIdentifier;
+
+  protected override createDiagramLoadingOptions(): DiagramLoadingOptions | undefined {
+    const requestModelOptions: Args = {};
+    if (this.diagramIdentifier.diff) {
+      requestModelOptions.diffId = this.diagramIdentifier.diff.id;
+      requestModelOptions.diffSide = this.diagramIdentifier.diff.side;
+      requestModelOptions.diffContent = this.diagramIdentifier.diff.content;
+    }
+    return {
+      requestModelOptions
+    };
+  }
+}


### PR DESCRIPTION
Implement inital (client-side) support for diagram diffing with the process editor

- Update configuration defaults for p.json files so that files associated with a git scheme are opened with the text editor by default -> When opening a diff view for a p.json file from the git view the default text compare editor is openend by default
- Add an entry to the title bar of the text diff editor that allows reopening in the diagram compare view (use artificial uris with pdiff extension so that we can distinguish between files that are openend normally and in compare mode)
- Update process editor provider to handle .pdiff uris
  - Extract diff info (id, side, uri) from pdiff uris forward it to the webview
- Update the webview so that it attaches optionally present diff information to the args of the `RequestModelAction`

Missing:
- Server-side implementation. Currently the optional diff args are not evaluated and the server just openes the file normally