### PR TITLE
Improve raising process

### DIFF
--- a/.github/workflows/electron-integration.yml
+++ b/.github/workflows/electron-integration.yml
@@ -27,7 +27,7 @@ jobs:
           npm run update:axonivy:next
           npm install
           npm run build:production
-          npm run download:engine https://dev.axonivy.com/permalink/dev/axonivy-engine.zip
+          npm run engine:download https://dev.axonivy.com/permalink/dev/axonivy-engine.zip
           rm -r extension/AxonIvyEngine/system/demo-applications
           npm run test:playwright:download:vscode
           extension/AxonIvyEngine/bin/AxonIvyEngine startdaemon

--- a/.github/workflows/openvscode-server-integration.yml
+++ b/.github/workflows/openvscode-server-integration.yml
@@ -29,7 +29,7 @@ jobs:
           npm run build:production
           npm install -D @playwright/test@latest
           npx playwright install --with-deps chromium
-          npm run download:engine https://dev.axonivy.com/permalink/dev/axonivy-engine.zip
+          npm run engine:download https://dev.axonivy.com/permalink/dev/axonivy-engine.zip
           rm -r extension/AxonIvyEngine/system/demo-applications
           wget -O openvsc.tar.gz https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-$OPEN_VSCODE_VERSION/openvscode-server-$OPEN_VSCODE_VERSION-linux-x64.tar.gz
           tar -xzf openvsc.tar.gz --strip-components=1 --one-top-level=openvsc

--- a/.ivy/raise-deps.sh
+++ b/.ivy/raise-deps.sh
@@ -4,6 +4,8 @@ set -e
 shopt -s globstar
 # likely not working on mac
 
+mvn --batch-mode versions:set-property versions:commit -Dproperty=openapi.version -DnewVersion=${1} -DallowSnapshots=true
+
 # This should only be done if branch is not master...
 # sed -i -E "s|core_product-engine/job/master/|core_product-engine/job/release%2F${1/.[0-9]-SNAPSHOT/}/|" build/**/Jenkinsfile
 sed -i -E "s/(\"@axonivy[^\"]*\"): \"[^\"]*\"/\1: \"~${1/SNAPSHOT/next}\"/" package.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The available VS Code extension can be found under `/extension`.
 
 - `npm install`: install all packages
 - `npm run build`: build the extension and webviews
-- `npm run download:engine`: download and unpack the latest master engine
+- `npm run engine:download`: download and unpack the latest master engine
 - `npm run package`: package the extension as .vsix file
 
 ### Generate REST Client from Axon Ivy OpenAPI
@@ -16,13 +16,13 @@ The available VS Code extension can be found under `/extension`.
 To access the REST API of the engine, we generate the Axios client from OpenAPI. For the creation, it is expected that the OpenAPI specification is located under `target/engine/openapi.json`. The easiest way to retrieve the specification is to run the following command (Maven needed). Otherwise, you can load the file from https://jenkins.ivyteam.io/job/core_openapi/
 
 ```shellscript
-npm run download:openapi
+npm run openapi:download
 ```
 
 For client generation run:
 
 ```shellscript
-npm run codegen:openapi
+npm run openapi:codegen
 ```
 
 ## Debugging the extension

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
       steps {
         script {
           sh 'npm run package'
-          sh 'npm run download:engine ' + params.engineDownloadUrl
+          sh 'npm run engine:download ' + params.engineDownloadUrl
           sh 'npm run package:with:engine'
           archiveArtifacts 'extension/**/*.vsix'
         }

--- a/build/integration/openvscode-server/Jenkinsfile
+++ b/build/integration/openvscode-server/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
             npm run update:axonivy:next
             npm install
             npm run build:production
-            npm run download:engine ${params.engineDownloadUrl}
+            npm run engine:download ${params.engineDownloadUrl}
             extension/AxonIvyEngine/bin/AxonIvyEngine startdaemon > ivy-engine-console.out &
             wget -O openvsc.tar.gz https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-${params.openvscodeVersion}/openvscode-server-${params.openvscodeVersion}-linux-x64.tar.gz
             tar -xzf openvsc.tar.gz --strip-components=1 --one-top-level=openvsc

--- a/build/integration/windows/Jenkinsfile
+++ b/build/integration/windows/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
           bat 'npm run update:axonivy:next'
           bat 'npm install'
           bat 'npm run build:production'
-          bat 'npm run download:engine'
+          bat 'npm run engine:download'
         }
       }
     }
@@ -60,8 +60,8 @@ pipeline {
         nodejs(nodeJSInstallationName: '22.17.1') {
           catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
             script {
-              bat 'npm run download:openapi'
-              bat 'npm run codegen:openapi'
+              bat 'npm run openapi:download'
+              bat 'npm run openapi:codegen'
               bat 'npm run type'
               bat 'npm run lint:ci'
             }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "scripts": {
     "build": "lerna run build",
     "build:production": "lerna run build:production",
-    "download:engine": "node --experimental-strip-types scripts/download-engine.mts",
-    "download:openapi": "mvn clean validate",
-    "codegen:openapi": "orval",
+    "engine:download": "node --experimental-strip-types scripts/download-engine.mts",
+    "openapi:download": "mvn clean validate",
+    "openapi:codegen": "orval",
     "clean": "lerna run clean",
     "lint": "eslint",
     "lint:ci": "eslint -o eslint.xml -f checkstyle",

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,11 @@
   <version>13.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
+  <properties>
+    <!-- Will be raise by the raise-deps.sh script -->
+    <openapi.version>13.2.0-SNAPSHOT</openapi.version>
+  </properties>
+
   <repositories>
     <repository>
       <id>nexus.ivyteam.io</id>
@@ -21,7 +26,7 @@
     <dependency>
       <groupId>ch.ivyteam.openapi</groupId>
       <artifactId>openapi</artifactId>
-      <version>${project.version}</version>
+      <version>${openapi.version}</version>
       <type>json</type>
     </dependency>
   </dependencies>


### PR DESCRIPTION
- Do the raise version of the open api specs in the raise-deps step, otherwise the build fails until the openapi build runs