### PR TITLE
Remove eslint validate settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
     "source.organizeImports": "always"
   },
   "editor.insertSpaces": true,
-  "eslint.validate": ["javascript", "typescript"],
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true

--- a/vscode-designer.code-workspace
+++ b/vscode-designer.code-workspace
@@ -52,7 +52,6 @@
       "source.organizeImports": "always"
     },
     "editor.insertSpaces": true,
-    "eslint.validate": ["javascript", "typescript"],
     "search.exclude": {
       "**/node_modules": true,
       "**/lib": true


### PR DESCRIPTION
With it defined no eslint validations will appear in tsx files per default. The default (without anything configured) is better today as the configs will no longer be merged with the default