### PR TITLE
Feature/XIVY-18697-multi-step-input

### DIFF
--- a/extension/src/project-explorer/new-case-map.ts
+++ b/extension/src/project-explorer/new-case-map.ts
@@ -1,6 +1,6 @@
 import { Uri, window } from 'vscode';
 import { IvyEngineManager } from '../engine/engine-manager';
-import { resolveNamespaceFromPath, validateArtifactName, validateNamespace } from './utils/util';
+import { resolveNamespaceFromPath, validateNamespace, validateProjectArtifactName } from './utils/util';
 
 export const addNewCaseMap = async (selectedUri: Uri, projectDir: string) => {
   const input = await collectNewCaseMapParams(selectedUri, projectDir);
@@ -26,7 +26,7 @@ const collectName = async () => {
     title: 'Case Map Name',
     placeHolder: 'Enter a name',
     ignoreFocusOut: true,
-    validateInput: validateArtifactName
+    validateInput: validateProjectArtifactName
   });
 };
 

--- a/extension/src/project-explorer/new-data-class.ts
+++ b/extension/src/project-explorer/new-data-class.ts
@@ -1,6 +1,6 @@
 import { Uri, window } from 'vscode';
 import { IvyEngineManager } from '../engine/engine-manager';
-import { resolveNamespaceFromPath, validateArtifactName, validateDotSeparatedName } from './utils/util';
+import { resolveNamespaceFromPath, validateDotSeparatedName, validateProjectArtifactName } from './utils/util';
 
 export const addNewDataClass = async (selectedUri: Uri, projectDir: string) => {
   const input = await collectNewDataClassParams(selectedUri, projectDir);
@@ -16,16 +16,12 @@ export const addNewEntityClass = async (selectedUri: Uri, projectDir: string) =>
   }
 };
 
-const collectNewDataClassParams = async (
-  selectedUri: Uri,
-  projectDir: string,
-  type: 'Data Class' | 'Entity Class' = 'Data Class'
-) => {
+const collectNewDataClassParams = async (selectedUri: Uri, projectDir: string, type: 'Data Class' | 'Entity Class' = 'Data Class') => {
   const name = await window.showInputBox({
     title: `${type} Name`,
     placeHolder: 'Enter a name',
     ignoreFocusOut: true,
-    validateInput: validateArtifactName
+    validateInput: validateProjectArtifactName
   });
   if (!name) {
     return;

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -6,7 +6,7 @@ import type { ProcessInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
 import { IvyProjectExplorer } from './ivy-project-explorer';
 import { type InputStep, type MSStateBase, MultiStepInput } from './utils/multi-step-input';
-import { resolveNamespaceFromPath, validateArtifactName, validateNamespace } from './utils/util';
+import { resolveNamespaceFromPath, validateNamespace, validateProjectArtifactName } from './utils/util';
 
 export type ProcessKind = 'Business Process' | 'Callable Sub Process' | 'Web Service Process' | '';
 
@@ -71,7 +71,7 @@ export const addNewProcess = async (kind: ProcessKind = 'Business Process', pid?
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
       value: state.name,
-      validationFunction: validateArtifactName,
+      validationFunction: validateProjectArtifactName,
       onBack: (typedValue: string) => {
         state.name = typedValue;
       }

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -120,7 +120,6 @@ export const addNewProcess = async (kind: ProcessKind = 'Business Process', pid?
 
     await IvyEngineManager.instance.createProcess(createProcessInput);
   } else {
-    logErrorMessage('Process creation cancelled or invalid input provided. Current input state: ' + JSON.stringify(newProcessData));
-    return;
+    throw new Error('Process creation failed. Current input state: ' + JSON.stringify(newProcessData));
   }
 };

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -94,9 +94,8 @@ export const addNewProcess = async (kind: ProcessKind = 'Business Process', pid?
     });
   };
 
-  // Define step order, set execution counter for steps that might have defaults and set value automatically
+  // Define step order
   const steps: InputStep<NewProcessState>[] = [stepProject, stepName, stepNamespace];
-  stepProject.execCounter = 0;
 
   const newProcessData: NewProcessState = {
     dialogTitle: `Add New ${kind}`,

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -71,7 +71,10 @@ export const addNewProcess = async (kind: ProcessKind = 'Business Process', pid?
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
       value: state.name,
-      validationFunction: validateArtifactName
+      validationFunction: validateArtifactName,
+      onBack: (typedValue: string) => {
+        state.name = typedValue;
+      }
     });
   };
 
@@ -87,7 +90,10 @@ export const addNewProcess = async (kind: ProcessKind = 'Business Process', pid?
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
       value: state.namespace,
-      validationFunction: validateNamespace
+      validationFunction: validateNamespace,
+      onBack: (typedValue: string) => {
+        state.namespace = typedValue;
+      }
     });
   };
 

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -22,7 +22,6 @@ interface NewProcessState extends MSStateBase {
   projectSelection: ProjectSelection;
   name: string;
   namespace: string;
-  namespaceFromPath?: string;
   projectSelectionFromPath?: ProjectSelection;
 }
 
@@ -41,8 +40,9 @@ export const addNewProcess = async (kind: ProcessKind = 'Business Process', pid?
   }
 
   const stepProject: InputStep<NewProcessState> = async (input: MultiStepInput<NewProcessState>, state: NewProcessState) => {
-    if (state.projectSelectionFromPath && stepProject.execCounter !== undefined && stepProject.execCounter === 0) {
+    if (state.projectSelectionFromPath && (state.projectSelection.label === '' || state.projectSelection.label === undefined)) {
       state.projectSelection = state.projectSelectionFromPath;
+      state.projectSelectionFromPath = undefined;
     } else {
       state.projectSelection = await input.showQuickPick({
         title: state.dialogTitle,
@@ -80,9 +80,6 @@ export const addNewProcess = async (kind: ProcessKind = 'Business Process', pid?
 
   // Step 3 - Enter the namespace of the process to be created
   const stepNamespace: InputStep<NewProcessState> = async (input: MultiStepInput<NewProcessState>, state: NewProcessState) => {
-    if (state.namespaceFromPath) {
-      state.namespace = state.namespaceFromPath;
-    }
     state.namespace = await input.showTextInput({
       title: state.dialogTitle,
       titleSuffix: ' - Choose process namespace',
@@ -106,8 +103,7 @@ export const addNewProcess = async (kind: ProcessKind = 'Business Process', pid?
     currentStep: 1,
     totalSteps: steps.length,
     name: '',
-    namespace: '',
-    namespaceFromPath: namespaceFromPath,
+    namespace: typeof namespaceFromPath === 'string' && namespaceFromPath.trim() !== '' ? namespaceFromPath : '',
     projectSelection: {} as ProjectSelection,
     projectSelectionFromPath: projectSelectionFromPath
   };

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -67,7 +67,7 @@ export const addNewProcess = async (kind: ProcessKind = 'Business Process', pid?
     state.name = await input.showTextInput({
       title: state.dialogTitle,
       titleSuffix: ' - Choose process name',
-      placeholder: 'Enter a name. Allowed characters: a-z, A-Z, 0-9, -, _',
+      placeholder: 'Enter a name. Allowed characters: a-z, A-Z, 0-9, _',
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
       value: state.name,
@@ -83,7 +83,7 @@ export const addNewProcess = async (kind: ProcessKind = 'Business Process', pid?
     state.namespace = await input.showTextInput({
       title: state.dialogTitle,
       titleSuffix: ' - Choose process namespace',
-      placeholder: 'Enter Namespace separated by "/"',
+      placeholder: 'Enter Namespace separated by "/". Allowed characters: a-z, A-Z, 0-9, _, /',
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
       value: state.namespace,

--- a/extension/src/project-explorer/new-project.ts
+++ b/extension/src/project-explorer/new-project.ts
@@ -3,7 +3,7 @@ import { FileType, Uri, window, workspace } from 'vscode';
 import { logInformationMessage } from '../base/logging-util';
 import { IvyEngineManager } from '../engine/engine-manager';
 import { type TreeSelection, treeSelectionToUri } from './tree-selection';
-import { validateArtifactName, validateDotSeparatedName } from './utils/util';
+import { validateDotSeparatedName, validateProjectName } from './utils/util';
 
 export const addNewProject = async (selection: TreeSelection) => {
   const treeSelectionUri = await treeSelectionToUri(selection);
@@ -38,7 +38,7 @@ const collectNewProjectParams = async (selectedUri: Uri) => {
   const prompt = `Project Location: ${selectedUri.path}`;
   const name = await window.showInputBox({
     title: 'Project Name',
-    validateInput: validateArtifactName,
+    validateInput: validateProjectName,
     prompt,
     ignoreFocusOut: true
   });

--- a/extension/src/project-explorer/new-user-dialog.ts
+++ b/extension/src/project-explorer/new-user-dialog.ts
@@ -1,7 +1,7 @@
 import { Uri, window } from 'vscode';
 import type { HdInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
-import { resolveNamespaceFromPath, validateArtifactName, validateDotSeparatedName } from './utils/util';
+import { resolveNamespaceFromPath, validateDotSeparatedName, validateProjectArtifactName } from './utils/util';
 
 export const dialogTypes = ['JSF', 'Form', 'JSFOffline'] as const;
 export type DialogType = (typeof dialogTypes)[number];
@@ -62,7 +62,7 @@ const collectName = async () => {
     title: 'User Dialog Name',
     placeHolder: 'Enter a name',
     ignoreFocusOut: true,
-    validateInput: validateArtifactName
+    validateInput: validateProjectArtifactName
   });
 };
 

--- a/extension/src/project-explorer/utils/multi-step-input.ts
+++ b/extension/src/project-explorer/utils/multi-step-input.ts
@@ -70,7 +70,7 @@ export class MultiStepInput<T extends MSStateBase> {
           state.currentStep = stepIndex + 1;
           this.currentStep = steps[stepIndex];
         } else if (err == InputFlowAction.cancel) {
-          return;
+          throw new Error('Dialog cancelled by the user');
         } else {
           throw err;
         }

--- a/extension/src/project-explorer/utils/multi-step-input.ts
+++ b/extension/src/project-explorer/utils/multi-step-input.ts
@@ -12,10 +12,7 @@ const enum InputFlowAction {
   cancel
 }
 
-export type InputStep<T extends MSStateBase> = {
-  execCounter?: number;
-  (input: MultiStepInput<T>, state: T): Thenable<InputStep<T>> | Promise<void>;
-};
+export type InputStep<T extends MSStateBase> = (input: MultiStepInput<T>, state: T) => Thenable<InputStep<T>> | Promise<void>;
 
 interface TextInputParameters {
   title: string;
@@ -58,9 +55,6 @@ export class MultiStepInput<T extends MSStateBase> {
       }
       try {
         await this.currentStep(this, state);
-        if (this.currentStep.execCounter !== undefined) {
-          this.currentStep.execCounter++;
-        }
         stepIndex++;
         state.currentStep = stepIndex + 1;
         this.currentStep = steps[stepIndex];

--- a/extension/src/project-explorer/utils/multi-step-input.ts
+++ b/extension/src/project-explorer/utils/multi-step-input.ts
@@ -64,7 +64,9 @@ export class MultiStepInput<T extends MSStateBase> {
           state.currentStep = stepIndex + 1;
           this.currentStep = steps[stepIndex];
         } else if (err == InputFlowAction.cancel) {
-          throw new Error('Dialog cancelled by the user');
+          throw new Error('Dialog cancelled by the user', {
+            cause: err
+          });
         } else {
           throw err;
         }

--- a/extension/src/project-explorer/utils/util.test.ts
+++ b/extension/src/project-explorer/utils/util.test.ts
@@ -1,0 +1,112 @@
+import { expect, test, vi } from 'vitest';
+import { validateDotSeparatedName, validateNamespace } from './util';
+
+vi.mock('vscode', () => ({
+  FileType: { File: 1, Directory: 2 },
+  Uri: { joinPath: vi.fn(), file: vi.fn() },
+  workspace: { fs: { readFile: vi.fn(), stat: vi.fn() } }
+}));
+
+test('dotseparated valid single word', () => {
+  expect(validateDotSeparatedName('hello')).toBeUndefined();
+});
+
+test('dotseparated valid dot-separated words', () => {
+  expect(validateDotSeparatedName('com.example.project')).toBeUndefined();
+});
+
+test('dotseparated valid words with numbers', () => {
+  expect(validateDotSeparatedName('com.example2.v3')).toBeUndefined();
+});
+
+test('dotseparated valid words with underscores', () => {
+  expect(validateDotSeparatedName('com.my_project.util')).toBeUndefined();
+});
+
+test('dotseparated valid words with numbers and underscores', () => {
+  expect(validateDotSeparatedName('com.my_project2.util')).toBeUndefined();
+});
+
+test('dotseparated error empty string', () => {
+  expect(validateDotSeparatedName('')).toBeTruthy();
+});
+
+test('dotseparated error trailing dot', () => {
+  expect(validateDotSeparatedName('com.example.')).toBeTruthy();
+});
+
+test('dotseparated error leading dot', () => {
+  expect(validateDotSeparatedName('.com.example')).toBeTruthy();
+});
+
+test('dotseparated error consecutive dots', () => {
+  expect(validateDotSeparatedName('com..example')).toBeTruthy();
+});
+
+test('dotseparated error trailing whitespace', () => {
+  expect(validateDotSeparatedName('com.example ')).toBeTruthy();
+});
+
+test('dotseparated error leading whitespace', () => {
+  expect(validateDotSeparatedName(' com.example')).toBeTruthy();
+});
+
+test('dotseparated error hyphens', () => {
+  expect(validateDotSeparatedName('com.my-project')).toBeTruthy();
+});
+
+test('dotseparated error slash-separated input', () => {
+  expect(validateDotSeparatedName('com/example')).toBeTruthy();
+});
+
+test('namespace valid single word', () => {
+  expect(validateNamespace('hello')).toBeUndefined();
+});
+
+test('namespace valid slash-separated words', () => {
+  expect(validateNamespace('com/example/project')).toBeUndefined();
+});
+
+test('namespace valid words with numbers', () => {
+  expect(validateNamespace('com/example2/v3')).toBeUndefined();
+});
+
+test('namespace valid words with underscores before last group', () => {
+  expect(validateNamespace('com/my_project/util')).toBeUndefined();
+});
+
+test('namespace valid words with numbers and underscores before last group', () => {
+  expect(validateNamespace('4super_2com/my_project2/util')).toBeUndefined();
+});
+
+test('namespace valid empty string', () => {
+  expect(validateNamespace('')).toBeUndefined();
+});
+
+test('namespace error trailing slash', () => {
+  expect(validateNamespace('com/example/')).toBeTruthy();
+});
+
+test('namespace error leading slash', () => {
+  expect(validateNamespace('/com/example')).toBeTruthy();
+});
+
+test('namespace error consecutive slashes', () => {
+  expect(validateNamespace('com//example')).toBeTruthy();
+});
+
+test('namespace error trailing whitespace', () => {
+  expect(validateNamespace('com/example ')).toBeTruthy();
+});
+
+test('namespace error leading whitespace', () => {
+  expect(validateNamespace(' com/example')).toBeTruthy();
+});
+
+test('namespace error hyphens', () => {
+  expect(validateNamespace('com/my-project')).toBeTruthy();
+});
+
+test('namespace error dot-separated input', () => {
+  expect(validateNamespace('com.example')).toBeTruthy();
+});

--- a/extension/src/project-explorer/utils/util.ts
+++ b/extension/src/project-explorer/utils/util.ts
@@ -69,14 +69,14 @@ export const validateProjectName = (value: string) => {
 };
 
 export const validateDotSeparatedName = (value: string) => {
-  const pattern = /^\w+(\.\w+)*(\w+)*$/;
+  const pattern = /^\w+(\.\w+)*$/;
   if (pattern.test(value)) {
     return;
   }
-  return 'Enter Namespace separated by ".". Only letters, numbers, and underscores are allowed. No trailing whitespaces. Empty not allowed.';
+  return 'Enter Namespace separated by ".". Only letters, numbers, and underscores are allowed. Cannot be empty. No trailing whitespaces. Empty not allowed.';
 };
 export const validateNamespace = (value: string) => {
-  const pattern = /^(\w+(\/\w+)*(\w+)*)?$/;
+  const pattern = /^(\w+(\/\w+)*)?$/;
   if (pattern.test(value)) {
     return;
   }

--- a/extension/src/project-explorer/utils/util.ts
+++ b/extension/src/project-explorer/utils/util.ts
@@ -52,7 +52,15 @@ export const resolveDefaultNamespace = async (projectDir: string, target: Resour
   return target === 'processes' ? defaultNamespace.replaceAll('.', '/') : defaultNamespace;
 };
 
-export const validateArtifactName = (value: string) => {
+export const validateProjectArtifactName = (value: string) => {
+  const pattern = /^[\w]+$/;
+  if (pattern.test(value)) {
+    return;
+  }
+  return 'Only letters, numbers, and underscores are allowed. No trailing whitespaces.';
+};
+
+export const validateProjectName = (value: string) => {
   const pattern = /^[\w-]+$/;
   if (pattern.test(value)) {
     return;

--- a/extension/src/project-explorer/utils/util.ts
+++ b/extension/src/project-explorer/utils/util.ts
@@ -69,16 +69,16 @@ export const validateProjectName = (value: string) => {
 };
 
 export const validateDotSeparatedName = (value: string) => {
-  const pattern = /^\w+(\.\w+)*(-\w+)*$/;
+  const pattern = /^\w+(\.\w+)*(\w+)*$/;
   if (pattern.test(value)) {
     return;
   }
-  return 'Enter Namespace separated by ".". Only letters, numbers, underscores, and hyphens are allowed. No hyphen except for last group';
+  return 'Enter Namespace separated by ".". Only letters, numbers, and underscores are allowed. No trailing whitespaces. Empty not allowed.';
 };
 export const validateNamespace = (value: string) => {
-  const pattern = /^(\w+(\/\w+)*(-\w+)*)?$/;
+  const pattern = /^(\w+(\/\w+)*(\w+)*)?$/;
   if (pattern.test(value)) {
     return;
   }
-  return 'Enter Namespace separated by "/". Only letters, numbers, underscores, and hyphens are allowed. No hyphen except for last group';
+  return 'Enter Namespace separated by "/". Only letters, numbers, and underscores are allowed. No trailing whitespaces. Empty allowed.';
 };


### PR DESCRIPTION
Improve validation
- Split `validateArtifactName` into `validateProjectName` and `validateProjectArtifactName`. 
`validateProjectName` allows hyphen.
`validateProjectArtifactName` does not allow hyphen.

New Process
- Simplify, remove `execCounter` and `NewProcessState.namespaceFromPath`
- Fix bug where namespace default from selection was overriding manual user input.
- Add missing `onBack` methods
- Throw proper error on cancellation