### PR TITLE
XIVY-18855 Fix custom icons blocked by csp on localhost

### DIFF
--- a/extension/src/editors/webview-helper.ts
+++ b/extension/src/editors/webview-helper.ts
@@ -35,7 +35,7 @@ export const createWebViewContent = (context: ExtensionContext, webview: Webview
     content: `
       default-src 'none';
       style-src 'unsafe-inline' ${webview.cspSource};
-      img-src ${webview.cspSource} https: data:;
+      img-src ${webview.cspSource} https: http://localhost:* http://127.0.0.1:* data:;
       script-src 'nonce-${nonce}' *;
       worker-src ${webview.cspSource} blob: data:;
       font-src ${webview.cspSource};


### PR DESCRIPTION
https://axon-ivy.atlassian.net/browse/XIVY-18855?focusedCommentId=154995

<img width="818" height="361" alt="image" src="https://github.com/user-attachments/assets/2412b191-5882-4c37-883b-a456e683a2a8" />

I think this is indeed new... maybe also since the vscode update, which maybe included a new electron version or something like that?