### PR TITLE
XIVY-18702 multi-step input New Project

### DIFF
--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -208,7 +208,7 @@ export class IvyProjectExplorer {
     const existingIvyProjects = await this.getIvyProjects();
     for (const existingProject of existingIvyProjects) {
       if (isSubdirectoryOrEqual(existingProject, selectedUri.fsPath)) {
-        logInformationMessage('Cannot create a new project inside an existing Axon Ivy project. Select a valid directory.');
+        logErrorMessage('Cannot create a new project inside an existing Axon Ivy project. Select a valid directory.');
         return;
       }
     }

--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -17,6 +17,7 @@ import { addNewProcess, type ProcessKind } from './new-process';
 import { addNewProject } from './new-project';
 import { addNewUserDialog, type DialogType } from './new-user-dialog';
 import { treeSelectionToUri, treeUriToProjectPath, type TreeSelection } from './tree-selection';
+import { getWorkspaceFolder, isDirectory, isSubdirectoryOrEqual } from './utils/util';
 
 export const VIEW_ID = 'ivyProjects';
 
@@ -74,7 +75,7 @@ export class IvyProjectExplorer {
     registerCmd(`${VIEW_ID}.installLocalMarketProduct`, (s: TreeSelection) => this.installLocalMarketProduct(s));
     registerCmd(`${VIEW_ID}.installMarketProduct`, (s: TreeSelection) => this.installMarketProduct(s));
 
-    registerCmd(`${VIEW_ID}.addNewProject`, (s: TreeSelection) => addNewProject(s));
+    registerCmd(`${VIEW_ID}.addNewProject`, (s: TreeSelection) => this.addProject(s));
     registerCmd(`${VIEW_ID}.addNewHtmlDialog`, (s: TreeSelection, selections?: [TreeSelection], pid?: string) =>
       this.addUserDialog(s, 'JSF', pid)
     );
@@ -195,6 +196,23 @@ export class IvyProjectExplorer {
       return;
     }
     return debouncedAction(() => action(project), `${project}:actionKey:${actionKey}`, 1_000)();
+  }
+
+  public async addProject(selection: TreeSelection) {
+    const treeSelectionUri = await treeSelectionToUri(selection);
+    const selectedUri = (await isDirectory(treeSelectionUri)) ? treeSelectionUri : await getWorkspaceFolder();
+    if (!selectedUri) {
+      logInformationMessage('No valid directory selected');
+      return;
+    }
+    const existingIvyProjects = await this.getIvyProjects();
+    for (const existingProject of existingIvyProjects) {
+      if (isSubdirectoryOrEqual(existingProject, selectedUri.fsPath)) {
+        logInformationMessage('Cannot create a new project inside an existing Axon Ivy project. Select a valid directory.');
+        return;
+      }
+    }
+    await addNewProject(selectedUri);
   }
 
   public async addProcess(selection: TreeSelection, kind: ProcessKind, pid?: string) {

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -5,7 +5,7 @@ import { logErrorMessage } from '../base/logging-util';
 import type { ProcessInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
 import { IvyProjectExplorer } from './ivy-project-explorer';
-import { type InputStep, type MSStateBase, MultiStepInput } from './utils/multi-step-input';
+import { type InputStep, type MSStateBase, MultiStepCancelledError, MultiStepInput } from './utils/multi-step-input';
 import { resolveNamespaceFromPath, validateNamespace, validateProjectArtifactName } from './utils/util';
 
 export type ProcessKind = 'Business Process' | 'Callable Sub Process' | 'Web Service Process' | '';
@@ -107,7 +107,16 @@ export const addNewProcess = async (kind: ProcessKind = 'Business Process', pid?
     projectSelectionFromPath: projectSelectionFromPath
   };
 
-  await new MultiStepInput<NewProcessState>().stepThrough(steps, newProcessData);
+  try {
+    await new MultiStepInput<NewProcessState>().stepThrough(steps, newProcessData);
+  } catch (err) {
+    if (err instanceof MultiStepCancelledError) {
+      logErrorMessage(err.message);
+      return;
+    } else {
+      throw err;
+    }
+  }
 
   if (newProcessData.projectSelection && newProcessData.name) {
     const createProcessInput: NewProcessParams = {
@@ -120,6 +129,6 @@ export const addNewProcess = async (kind: ProcessKind = 'Business Process', pid?
 
     await IvyEngineManager.instance.createProcess(createProcessInput);
   } else {
-    throw new Error('Process creation failed. Current input state: ' + JSON.stringify(newProcessData));
+    throw new Error('Process creation failed due to corrupted input state. Current input state: ' + JSON.stringify(newProcessData));
   }
 };

--- a/extension/src/project-explorer/new-project.ts
+++ b/extension/src/project-explorer/new-project.ts
@@ -1,68 +1,93 @@
 import path from 'path';
-import { FileType, Uri, window, workspace } from 'vscode';
-import { logInformationMessage } from '../base/logging-util';
+import { Uri } from 'vscode';
+import { logErrorMessage } from '../base/logging-util';
+import type { NewProjectParams } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
-import { type TreeSelection, treeSelectionToUri } from './tree-selection';
+import { type InputStep, type MSStateBase, MultiStepCancelledError, MultiStepInput } from './utils/multi-step-input';
 import { validateDotSeparatedName, validateProjectName } from './utils/util';
 
-export const addNewProject = async (selection: TreeSelection) => {
-  const treeSelectionUri = await treeSelectionToUri(selection);
-  const selectedUri = (await isDirectory(treeSelectionUri)) ? treeSelectionUri : await getWorkspaceFolder();
-  if (!selectedUri) {
-    logInformationMessage('No valid directory selected');
-    return;
+interface NewProjectState extends MSStateBase {
+  projectName: string;
+  projectPath: string;
+  groupId: string;
+  projectId: string;
+}
+
+export const addNewProject = async (selectedUri: Uri) => {
+  const stepProjectName: InputStep<NewProjectState> = async (input: MultiStepInput<NewProjectState>, state: NewProjectState) => {
+    state.projectName = await input.showTextInput({
+      title: state.dialogTitle,
+      titleSuffix: ' - Choose project name',
+      placeholder: 'Enter a name. Allowed characters: a-z, A-Z, 0-9, _, -',
+      currentStep: state.currentStep,
+      totalSteps: state.totalSteps,
+      value: state.projectName,
+      validationFunction: validateProjectName,
+      onBack: (typedValue: string) => {
+        state.projectName = typedValue;
+      }
+    });
+    state.projectPath = path.join(selectedUri.fsPath, state.projectName);
+  };
+
+  const stepGroupId: InputStep<NewProjectState> = async (input: MultiStepInput<NewProjectState>, state: NewProjectState) => {
+    state.groupId = await input.showTextInput({
+      title: state.dialogTitle,
+      titleSuffix: ' - Choose a group ID',
+      placeholder: 'Enter a group ID. Allowed characters: a-z, A-Z, 0-9, _. Separate namespaces with dots, e.g. com.mycompany',
+      currentStep: state.currentStep,
+      totalSteps: state.totalSteps,
+      value: state.groupId,
+      validationFunction: validateDotSeparatedName,
+      onBack: (typedValue: string) => {
+        state.groupId = typedValue;
+      }
+    });
+  };
+
+  const stepProjectId: InputStep<NewProjectState> = async (input: MultiStepInput<NewProjectState>, state: NewProjectState) => {
+    state.projectId = await input.showTextInput({
+      title: state.dialogTitle,
+      titleSuffix: ' - Choose a project artifact ID',
+      placeholder: 'Enter a project ID. Allowed characters: a-z, A-Z, 0-9, _. Separate namespaces with dots, e.g. my.project',
+      currentStep: state.currentStep,
+      totalSteps: state.totalSteps,
+      value: state.projectId,
+      validationFunction: validateDotSeparatedName,
+      onBack: (typedValue: string) => {
+        state.projectId = typedValue;
+      }
+    });
+  };
+
+  const steps: InputStep<NewProjectState>[] = [stepProjectName, stepGroupId, stepProjectId];
+  const newProjectData: NewProjectState = {
+    dialogTitle: 'Create New Project',
+    currentStep: 1,
+    totalSteps: steps.length,
+    projectName: '',
+    projectPath: '',
+    groupId: '',
+    projectId: ''
+  };
+
+  try {
+    await new MultiStepInput<NewProjectState>().stepThrough(steps, newProjectData);
+  } catch (err) {
+    if (err instanceof MultiStepCancelledError) {
+      logErrorMessage(err.message);
+      return;
+    } else {
+      throw err;
+    }
   }
 
-  const input = await collectNewProjectParams(selectedUri);
-  if (input) {
-    await IvyEngineManager.instance.createProject(input);
-  }
-};
+  const createProjectInput: NewProjectParams & { path: string } = {
+    name: newProjectData.projectName,
+    groupId: newProjectData.groupId,
+    projectId: newProjectData.projectId,
+    path: newProjectData.projectPath
+  };
 
-const getWorkspaceFolder = async () => {
-  const workspaceFolders = workspace.workspaceFolders;
-  if (workspaceFolders?.length === 1 && workspaceFolders[0]) {
-    return workspaceFolders[0].uri;
-  }
-  return await window.showWorkspaceFolderPick().then(folder => folder?.uri);
-};
-
-const isDirectory = async (uri?: Uri) => {
-  if (!uri) {
-    return false;
-  }
-  return (await workspace.fs.stat(uri)).type === FileType.Directory;
-};
-
-const collectNewProjectParams = async (selectedUri: Uri) => {
-  const prompt = `Project Location: ${selectedUri.path}`;
-  const name = await window.showInputBox({
-    title: 'Project Name',
-    validateInput: validateProjectName,
-    prompt,
-    ignoreFocusOut: true
-  });
-  if (!name) {
-    return;
-  }
-  const projectPath = path.join(selectedUri.fsPath, name);
-  const groupId = await window.showInputBox({
-    title: 'Group Id',
-    value: name,
-    validateInput: value => validateDotSeparatedName(value),
-    ignoreFocusOut: true
-  });
-  if (!groupId) {
-    return;
-  }
-  const projectId = await window.showInputBox({
-    title: 'Project Id',
-    value: name,
-    validateInput: value => validateDotSeparatedName(value),
-    ignoreFocusOut: true
-  });
-  if (!projectId) {
-    return;
-  }
-  return { path: projectPath, name, groupId, projectId };
+  await IvyEngineManager.instance.createProject(createProjectInput);
 };

--- a/extension/src/project-explorer/new-project.ts
+++ b/extension/src/project-explorer/new-project.ts
@@ -32,8 +32,11 @@ export const addNewProject = async (selectedUri: Uri) => {
 
   const stepGroupId: InputStep<NewProjectState> = async (input: MultiStepInput<NewProjectState>, state: NewProjectState) => {
     if (state.groupId === undefined) {
-      if (state.projectName !== undefined && validateDotSeparatedName(state.projectName) === undefined) {
-        state.groupId = state.projectName;
+      if (state.projectName !== undefined) {
+        const sanitizedProjectName = state.projectName?.replace(/-/g, '.');
+        if (validateDotSeparatedName(sanitizedProjectName) === undefined) {
+          state.groupId = sanitizedProjectName;
+        }
       } else {
         state.groupId = '';
       }
@@ -54,8 +57,11 @@ export const addNewProject = async (selectedUri: Uri) => {
 
   const stepProjectId: InputStep<NewProjectState> = async (input: MultiStepInput<NewProjectState>, state: NewProjectState) => {
     if (state.projectId === undefined) {
-      if (state.projectName !== undefined && validateDotSeparatedName(state.projectName) === undefined) {
-        state.projectId = state.projectName;
+      if (state.projectName !== undefined) {
+        const sanitizedProjectName = state.projectName?.replace(/-/g, '.');
+        if (validateDotSeparatedName(sanitizedProjectName) === undefined) {
+          state.projectId = sanitizedProjectName;
+        }
       } else {
         state.projectId = '';
       }

--- a/extension/src/project-explorer/new-project.ts
+++ b/extension/src/project-explorer/new-project.ts
@@ -7,10 +7,10 @@ import { type InputStep, type MSStateBase, MultiStepCancelledError, MultiStepInp
 import { validateDotSeparatedName, validateProjectName } from './utils/util';
 
 interface NewProjectState extends MSStateBase {
-  projectName: string;
-  projectPath: string;
-  groupId: string;
-  projectId: string;
+  projectName?: string | undefined;
+  projectPath?: string | undefined;
+  groupId?: string | undefined;
+  projectId?: string | undefined;
 }
 
 export const addNewProject = async (selectedUri: Uri) => {
@@ -31,6 +31,13 @@ export const addNewProject = async (selectedUri: Uri) => {
   };
 
   const stepGroupId: InputStep<NewProjectState> = async (input: MultiStepInput<NewProjectState>, state: NewProjectState) => {
+    if (state.groupId === undefined) {
+      if (state.projectName !== undefined && validateDotSeparatedName(state.projectName) === undefined) {
+        state.groupId = state.projectName;
+      } else {
+        state.groupId = '';
+      }
+    }
     state.groupId = await input.showTextInput({
       title: state.dialogTitle,
       titleSuffix: ' - Choose a group ID',
@@ -46,6 +53,13 @@ export const addNewProject = async (selectedUri: Uri) => {
   };
 
   const stepProjectId: InputStep<NewProjectState> = async (input: MultiStepInput<NewProjectState>, state: NewProjectState) => {
+    if (state.projectId === undefined) {
+      if (state.projectName !== undefined && validateDotSeparatedName(state.projectName) === undefined) {
+        state.projectId = state.projectName;
+      } else {
+        state.projectId = '';
+      }
+    }
     state.projectId = await input.showTextInput({
       title: state.dialogTitle,
       titleSuffix: ' - Choose a project artifact ID',
@@ -64,11 +78,7 @@ export const addNewProject = async (selectedUri: Uri) => {
   const newProjectData: NewProjectState = {
     dialogTitle: 'Create New Project',
     currentStep: 1,
-    totalSteps: steps.length,
-    projectName: '',
-    projectPath: '',
-    groupId: '',
-    projectId: ''
+    totalSteps: steps.length
   };
 
   try {
@@ -82,12 +92,20 @@ export const addNewProject = async (selectedUri: Uri) => {
     }
   }
 
-  const createProjectInput: NewProjectParams & { path: string } = {
-    name: newProjectData.projectName,
-    groupId: newProjectData.groupId,
-    projectId: newProjectData.projectId,
-    path: newProjectData.projectPath
-  };
-
-  await IvyEngineManager.instance.createProject(createProjectInput);
+  if (
+    newProjectData.projectName !== undefined &&
+    newProjectData.groupId !== undefined &&
+    newProjectData.projectId !== undefined &&
+    newProjectData.projectPath !== undefined
+  ) {
+    const createProjectInput: NewProjectParams & { path: string } = {
+      name: newProjectData.projectName,
+      groupId: newProjectData.groupId,
+      projectId: newProjectData.projectId,
+      path: newProjectData.projectPath
+    };
+    await IvyEngineManager.instance.createProject(createProjectInput);
+  } else {
+    throw new Error('Project creation failed due to corrupted input state. Current input state: ' + JSON.stringify(newProjectData));
+  }
 };

--- a/extension/src/project-explorer/utils/multi-step-input.ts
+++ b/extension/src/project-explorer/utils/multi-step-input.ts
@@ -1,6 +1,14 @@
 import type { QuickInput, QuickPickItem } from 'vscode';
 import { Disposable, QuickInputButtons, window } from 'vscode';
 
+export class MultiStepCancelledError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MultiStepCancelledError';
+    Object.setPrototypeOf(this, MultiStepCancelledError.prototype);
+  }
+}
+
 export interface MSStateBase {
   dialogTitle: string;
   currentStep: number;
@@ -64,9 +72,7 @@ export class MultiStepInput<T extends MSStateBase> {
           state.currentStep = stepIndex + 1;
           this.currentStep = steps[stepIndex];
         } else if (err == InputFlowAction.cancel) {
-          throw new Error('Dialog cancelled by the user', {
-            cause: err
-          });
+          throw new MultiStepCancelledError('Dialog cancelled by the user');
         } else {
           throw err;
         }

--- a/extension/src/project-explorer/utils/util.ts
+++ b/extension/src/project-explorer/utils/util.ts
@@ -81,7 +81,7 @@ export const validateProjectArtifactName = (value: string) => {
   if (pattern.test(value)) {
     return;
   }
-  return 'Only letters, numbers, and underscores are allowed -- No trailing whitespaces -- Cannot be empty';
+  return 'Only letters, numbers, and underscores are allowed -- No spaces -- Cannot be empty';
 };
 
 export const validateProjectName = (value: string) => {
@@ -89,7 +89,7 @@ export const validateProjectName = (value: string) => {
   if (pattern.test(value)) {
     return;
   }
-  return 'Only letters, numbers, underscores, and hyphens are allowed -- No trailing whitespaces -- Cannot be empty';
+  return 'Only letters, numbers, underscores, and hyphens are allowed -- No spaces -- Cannot be empty';
 };
 
 export const validateDotSeparatedName = (value: string) => {
@@ -97,12 +97,13 @@ export const validateDotSeparatedName = (value: string) => {
   if (pattern.test(value)) {
     return;
   }
-  return 'Enter Namespace separated by "." -- Only letters, numbers, and underscores are allowed -- No trailing whitespaces -- Cannot be empty';
+  return 'Enter Namespace separated by "." -- Only letters, numbers, and underscores are allowed -- No spaces -- Cannot be empty';
 };
+
 export const validateNamespace = (value: string) => {
   const pattern = /^(\w+(\/\w+)*)?$/;
   if (pattern.test(value)) {
     return;
   }
-  return 'Enter Namespace separated by "/" -- Only letters, numbers, and underscores are allowed -- No trailing whitespaces -- Empty allowed.';
+  return 'Enter Namespace separated by "/" -- Only letters, numbers, and underscores are allowed -- No spaces -- Empty allowed.';
 };

--- a/extension/src/project-explorer/utils/util.ts
+++ b/extension/src/project-explorer/utils/util.ts
@@ -56,7 +56,11 @@ export const isDirectory = async (uri?: Uri) => {
   if (!uri) {
     return false;
   }
-  return (await workspace.fs.stat(uri)).type === FileType.Directory;
+  try {
+    return (await workspace.fs.stat(uri)).type === FileType.Directory;
+  } catch {
+    return false;
+  }
 };
 
 export const isSubdirectoryOrEqual = (parent: string, child: string) => {

--- a/extension/src/project-explorer/utils/util.ts
+++ b/extension/src/project-explorer/utils/util.ts
@@ -1,7 +1,7 @@
 import { XMLParser } from 'fast-xml-parser';
 import path from 'path';
 import type { FileStat } from 'vscode';
-import { FileType, Uri, workspace } from 'vscode';
+import { FileType, Uri, window, workspace } from 'vscode';
 
 const defaultNamespaceOf = (projecDir: string) => {
   const designerPrefs = Uri.joinPath(Uri.file(projecDir), 'pom.xml');
@@ -52,12 +52,32 @@ export const resolveDefaultNamespace = async (projectDir: string, target: Resour
   return target === 'processes' ? defaultNamespace.replaceAll('.', '/') : defaultNamespace;
 };
 
+export const isDirectory = async (uri?: Uri) => {
+  if (!uri) {
+    return false;
+  }
+  return (await workspace.fs.stat(uri)).type === FileType.Directory;
+};
+
+export const isSubdirectoryOrEqual = (parent: string, child: string) => {
+  const relative = path.relative(parent, child);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+};
+
+export const getWorkspaceFolder = async () => {
+  const workspaceFolders = workspace.workspaceFolders;
+  if (workspaceFolders?.length === 1 && workspaceFolders[0]) {
+    return workspaceFolders[0].uri;
+  }
+  return await window.showWorkspaceFolderPick().then(folder => folder?.uri);
+};
+
 export const validateProjectArtifactName = (value: string) => {
   const pattern = /^[\w]+$/;
   if (pattern.test(value)) {
     return;
   }
-  return 'Only letters, numbers, and underscores are allowed. No trailing whitespaces.';
+  return 'Only letters, numbers, and underscores are allowed -- No trailing whitespaces -- Cannot be empty';
 };
 
 export const validateProjectName = (value: string) => {
@@ -65,7 +85,7 @@ export const validateProjectName = (value: string) => {
   if (pattern.test(value)) {
     return;
   }
-  return 'Only letters, numbers, underscores, and hyphens are allowed. No trailing whitespaces.';
+  return 'Only letters, numbers, underscores, and hyphens are allowed -- No trailing whitespaces -- Cannot be empty';
 };
 
 export const validateDotSeparatedName = (value: string) => {
@@ -73,12 +93,12 @@ export const validateDotSeparatedName = (value: string) => {
   if (pattern.test(value)) {
     return;
   }
-  return 'Enter Namespace separated by ".". Only letters, numbers, and underscores are allowed. Cannot be empty. No trailing whitespaces. Empty not allowed.';
+  return 'Enter Namespace separated by "." -- Only letters, numbers, and underscores are allowed -- No trailing whitespaces -- Cannot be empty';
 };
 export const validateNamespace = (value: string) => {
   const pattern = /^(\w+(\/\w+)*)?$/;
   if (pattern.test(value)) {
     return;
   }
-  return 'Enter Namespace separated by "/". Only letters, numbers, and underscores are allowed. No trailing whitespaces. Empty allowed.';
+  return 'Enter Namespace separated by "/" -- Only letters, numbers, and underscores are allowed -- No trailing whitespaces -- Empty allowed.';
 };

--- a/playwright/tests/integration/create-project.spec.ts
+++ b/playwright/tests/integration/create-project.spec.ts
@@ -9,17 +9,20 @@ test.describe('Create Project', () => {
   test.use({ workspace: empty });
 
   test('Add Project and execute init Process', async ({ page }) => {
+    const projectName = 'testProject';
+    const projectNamespace = 'testProjectNamespace';
+    const projectId = 'testProjectId';
     const explorer = new FileExplorer(page);
-    await explorer.addNestedProject('parent', 'testProject');
+    await explorer.addNestedProject('parent', projectName, projectNamespace, projectId);
     await explorer.hasStatusMessage('Finished: Create new Project', 60_000);
-    await explorer.hasNode(`parent${path.sep}testProject`);
+    await explorer.hasNode(`parent${path.sep}${projectName}`);
 
     const problemsView = await ProblemsView.initProblemsView(page);
     await problemsView.hasNoMarker();
 
     const processEditor = new ProcessEditor(page, 'BusinessProcess.p.json');
     await processEditor.isViewVisible();
-    await processEditor.hasBreadCrumbs('parent', 'testProject', 'processes', 'testProject', 'BusinessProcess.p.json');
+    await processEditor.hasBreadCrumbs('parent', projectName, 'processes', projectNamespace, 'BusinessProcess.p.json');
     const start = processEditor.locatorForElementType('g.start\\:requestStart');
     const end = processEditor.locatorForElementType('g.end\\:taskEnd');
     await processEditor.startProcessAndAssertExecuted(start, end);

--- a/playwright/tests/integration/create-project.spec.ts
+++ b/playwright/tests/integration/create-project.spec.ts
@@ -5,7 +5,7 @@ import { ProblemsView } from '../page-objects/problems-view';
 import { ProcessEditor } from '../page-objects/process-editor';
 import { empty } from '../workspaces/workspace';
 
-test.describe.only('Create Project', () => {
+test.describe('Create Project', () => {
   test.use({ workspace: empty });
 
   test('Add Project and execute init Process', async ({ page }) => {

--- a/playwright/tests/integration/create-project.spec.ts
+++ b/playwright/tests/integration/create-project.spec.ts
@@ -10,10 +10,8 @@ test.describe('Create Project', () => {
 
   test('Add Project and execute init Process', async ({ page }) => {
     const projectName = 'testProject';
-    const projectNamespace = 'testProjectNamespace';
-    const projectId = 'testProjectId';
     const explorer = new FileExplorer(page);
-    await explorer.addNestedProject('parent', projectName, projectNamespace, projectId);
+    await explorer.addNestedProject('parent', projectName);
     await explorer.hasStatusMessage('Finished: Create new Project', 60_000);
     await explorer.hasNode(`parent${path.sep}${projectName}`);
 
@@ -22,7 +20,7 @@ test.describe('Create Project', () => {
 
     const processEditor = new ProcessEditor(page, 'BusinessProcess.p.json');
     await processEditor.isViewVisible();
-    await processEditor.hasBreadCrumbs('parent', projectName, 'processes', projectNamespace, 'BusinessProcess.p.json');
+    await processEditor.hasBreadCrumbs('parent', projectName, 'processes', projectName, 'BusinessProcess.p.json');
     const start = processEditor.locatorForElementType('g.start\\:requestStart');
     const end = processEditor.locatorForElementType('g.end\\:taskEnd');
     await processEditor.startProcessAndAssertExecuted(start, end);

--- a/playwright/tests/integration/create-project.spec.ts
+++ b/playwright/tests/integration/create-project.spec.ts
@@ -5,7 +5,7 @@ import { ProblemsView } from '../page-objects/problems-view';
 import { ProcessEditor } from '../page-objects/process-editor';
 import { empty } from '../workspaces/workspace';
 
-test.describe('Create Project', () => {
+test.describe.only('Create Project', () => {
   test.use({ workspace: empty });
 
   test('Add Project and execute init Process', async ({ page }) => {

--- a/playwright/tests/page-objects/explorer-view.ts
+++ b/playwright/tests/page-objects/explorer-view.ts
@@ -84,7 +84,7 @@ export class FileExplorer extends ExplorerView {
     await this.page.keyboard.press('Enter');
   }
 
-  async addNestedProject(rootFolder: string, projectName: string) {
+  async addNestedProject(rootFolder: string, projectName: string, projectNamespace: string, projectId: string) {
     await this.viewLocator.click();
     await this.addFolder(rootFolder);
     await this.viewLocator.getByText(rootFolder).click({ button: 'right' });
@@ -96,8 +96,8 @@ export class FileExplorer extends ExplorerView {
     await expect(newProject).toBeHidden();
 
     await this.provideUserInput(projectName);
-    await this.provideUserInput();
-    await this.provideUserInput();
+    await this.provideUserInput(projectNamespace);
+    await this.provideUserInput(projectId);
   }
 
   async addProcess(processName: string, kind: 'Business Process' | 'Callable Sub Process' | 'Web Service Process', namespace?: string) {

--- a/playwright/tests/page-objects/explorer-view.ts
+++ b/playwright/tests/page-objects/explorer-view.ts
@@ -84,7 +84,7 @@ export class FileExplorer extends ExplorerView {
     await this.page.keyboard.press('Enter');
   }
 
-  async addNestedProject(rootFolder: string, projectName: string, projectNamespace: string, projectId: string) {
+  async addNestedProject(rootFolder: string, projectName: string) {
     await this.viewLocator.click();
     await this.addFolder(rootFolder);
     await this.viewLocator.getByText(rootFolder).click({ button: 'right' });
@@ -96,8 +96,8 @@ export class FileExplorer extends ExplorerView {
     await expect(newProject).toBeHidden();
 
     await this.provideUserInput(projectName);
-    await this.provideUserInput(projectNamespace);
-    await this.provideUserInput(projectId);
+    await this.provideUserInput();
+    await this.provideUserInput();
   }
 
   async addProcess(processName: string, kind: 'Business Process' | 'Callable Sub Process' | 'Web Service Process', namespace?: string) {


### PR DESCRIPTION
Multi-step input dialog for New Project
- Try to use first input `projectName` for `groupId` and `projectId`. If not possible, set both to empty.
- Prohibit nested `New Project`.
If File Explorer selection is an ivy project, rightclick -> New Project will fail with warning
- Allow New Project in arbitrary folder
User can run `New Project` in folders like `.vscode`, this is not prohibited
- Move utility functions into `project-explorer/utils/util.ts`
  - `isDirectory`
  - `isSubdirectoryOrEqual`
  - `getWorkspaceFolder`
- Fix test `create-project.spec.ts`
  - Add missing namespace and id arguments in helper `addNestedProject`, since they cannot be empty inputs.


General multi-step improvements
- Custom error `MultiStepCancelledError` if users presses Esc. Implementing commands can catch it and handle it. Currently, the dialog is aborted, but not with an error (intrusive) but a log message.