### PR TITLE
XIVY-18903 various refactorings

### DIFF
--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -212,27 +212,21 @@ export class IvyProjectExplorer {
   }
 
   public async addProcess(selection: TreeSelection, kind: ProcessKind, pid?: string) {
-    const hasIvyProjects = await this.hasIvyProjects();
-    if (!hasIvyProjects) {
-      logErrorMessage('No Axon Ivy projects in the workspace. Create an Axon Ivy project first.');
+    const addCommandContext = await this.getAddCommandSelectionContext(selection);
+    if (!addCommandContext) {
       return;
     }
-    const existingProjects = await this.getIvyProjects();
-    const uri = await treeSelectionToUri(selection);
-    const projectPath = uri ? await treeUriToProjectPath(uri, this.getIvyProjects()) : undefined;
-    await addNewProcess(kind, existingProjects, pid, uri, projectPath);
+    const [existingProjects, uriSelection, projectPathSelection] = addCommandContext;
+    await addNewProcess(kind, existingProjects, pid, uriSelection, projectPathSelection);
   }
 
   private async addCaseMap(selection: TreeSelection) {
-    const hasIvyProjects = await this.hasIvyProjects();
-    if (!hasIvyProjects) {
-      logErrorMessage('No Axon Ivy projects in the workspace. Create an Axon Ivy project first.');
+    const addCommandContext = await this.getAddCommandSelectionContext(selection);
+    if (!addCommandContext) {
       return;
     }
-    const existingProjects = await this.getIvyProjects();
-    const uri = await treeSelectionToUri(selection);
-    const projectPath = uri ? await treeUriToProjectPath(uri, this.getIvyProjects()) : undefined;
-    await addNewCaseMap(existingProjects, uri, projectPath);
+    const [existingProjects, uriSelection, projectPathSelection] = addCommandContext;
+    await addNewCaseMap(existingProjects, uriSelection, projectPathSelection);
   }
 
   public async importBpmnProcess(selection: TreeSelection) {
@@ -270,39 +264,30 @@ export class IvyProjectExplorer {
   }
 
   public async addUserDialog(selection: TreeSelection, type: DialogType, pid?: string) {
-    const hasIvyProjects = await this.hasIvyProjects();
-    if (!hasIvyProjects) {
-      logErrorMessage('No Axon Ivy projects in the workspace. Create an Axon Ivy project first.');
+    const addCommandContext = await this.getAddCommandSelectionContext(selection);
+    if (!addCommandContext) {
       return;
     }
-    const existingProjects = await this.getIvyProjects();
-    const uri = await treeSelectionToUri(selection);
-    const projectPath = uri ? await treeUriToProjectPath(uri, this.getIvyProjects()) : undefined;
-    await addNewUserDialog(type, existingProjects, pid, uri, projectPath);
+    const [existingProjects, uriSelection, projectPathSelection] = addCommandContext;
+    await addNewUserDialog(type, existingProjects, pid, uriSelection, projectPathSelection);
   }
 
   private async addDataClass(selection: TreeSelection) {
-    const hasIvyProjects = await this.hasIvyProjects();
-    if (!hasIvyProjects) {
-      logErrorMessage('No Axon Ivy projects in the workspace. Create an Axon Ivy project first.');
+    const addCommandContext = await this.getAddCommandSelectionContext(selection);
+    if (!addCommandContext) {
       return;
     }
-    const existingProjects = await this.getIvyProjects();
-    const uri = await treeSelectionToUri(selection);
-    const projectPath = uri ? await treeUriToProjectPath(uri, this.getIvyProjects()) : undefined;
-    await addNewDataClass('Data Class', existingProjects, uri, projectPath);
+    const [existingProjects, uriSelection, projectPathSelection] = addCommandContext;
+    await addNewDataClass('Data Class', existingProjects, uriSelection, projectPathSelection);
   }
 
   private async addEntityClass(selection: TreeSelection) {
-    const hasIvyProjects = await this.hasIvyProjects();
-    if (!hasIvyProjects) {
-      logErrorMessage('No Axon Ivy projects in the workspace. Create an Axon Ivy project first.');
+    const addCommandContext = await this.getAddCommandSelectionContext(selection);
+    if (!addCommandContext) {
       return;
     }
-    const existingProjects = await this.getIvyProjects();
-    const uri = await treeSelectionToUri(selection);
-    const projectPath = uri ? await treeUriToProjectPath(uri, this.getIvyProjects()) : undefined;
-    await addNewDataClass('Entity Class', existingProjects, uri, projectPath);
+    const [existingProjects, uriSelection, projectPathSelection] = addCommandContext;
+    await addNewDataClass('Entity Class', existingProjects, uriSelection, projectPathSelection);
   }
 
   public async setProjectExplorerActivationCondition(hasIvyProjects: boolean) {
@@ -352,6 +337,18 @@ export class IvyProjectExplorer {
 
   private async hasIvyProjects() {
     return this.treeDataProvider.hasIvyProjects();
+  }
+
+  private async getAddCommandSelectionContext(selection: TreeSelection) {
+    const hasIvyProjects = await this.hasIvyProjects();
+    if (!hasIvyProjects) {
+      logErrorMessage('No Axon Ivy projects in the workspace. Create an Axon Ivy project first.');
+      return;
+    }
+    const existingProjects = await this.getIvyProjects();
+    const uri = await treeSelectionToUri(selection);
+    const projectPath = uri ? await treeUriToProjectPath(uri, Promise.resolve(existingProjects)) : undefined;
+    return [existingProjects, uri, projectPath] as const;
   }
 
   static get instance() {

--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -212,12 +212,11 @@ export class IvyProjectExplorer {
   }
 
   public async addProcess(selection: TreeSelection, kind: ProcessKind, pid?: string) {
-    const addCommandContext = await this.getAddCommandSelectionContext(selection);
-    if (!addCommandContext) {
+    const addCommandSelectionContext = await this.getAddCommandSelectionContext(selection);
+    if (!addCommandSelectionContext) {
       return;
     }
-    const [existingProjects, uriSelection, projectPathSelection] = addCommandContext;
-    await addNewProcess(kind, existingProjects, pid, uriSelection, projectPathSelection);
+    await addNewProcess(addCommandSelectionContext, kind, pid);
   }
 
   private async addCaseMap(selection: TreeSelection) {
@@ -225,8 +224,7 @@ export class IvyProjectExplorer {
     if (!addCommandContext) {
       return;
     }
-    const [existingProjects, uriSelection, projectPathSelection] = addCommandContext;
-    await addNewCaseMap(existingProjects, uriSelection, projectPathSelection);
+    await addNewCaseMap(addCommandContext);
   }
 
   public async importBpmnProcess(selection: TreeSelection) {
@@ -268,8 +266,7 @@ export class IvyProjectExplorer {
     if (!addCommandContext) {
       return;
     }
-    const [existingProjects, uriSelection, projectPathSelection] = addCommandContext;
-    await addNewUserDialog(type, existingProjects, pid, uriSelection, projectPathSelection);
+    await addNewUserDialog(addCommandContext, type, pid);
   }
 
   private async addDataClass(selection: TreeSelection) {
@@ -277,8 +274,7 @@ export class IvyProjectExplorer {
     if (!addCommandContext) {
       return;
     }
-    const [existingProjects, uriSelection, projectPathSelection] = addCommandContext;
-    await addNewDataClass('Data Class', existingProjects, uriSelection, projectPathSelection);
+    await addNewDataClass('Data Class', addCommandContext);
   }
 
   private async addEntityClass(selection: TreeSelection) {
@@ -286,8 +282,7 @@ export class IvyProjectExplorer {
     if (!addCommandContext) {
       return;
     }
-    const [existingProjects, uriSelection, projectPathSelection] = addCommandContext;
-    await addNewDataClass('Entity Class', existingProjects, uriSelection, projectPathSelection);
+    await addNewDataClass('Entity Class', addCommandContext);
   }
 
   public async setProjectExplorerActivationCondition(hasIvyProjects: boolean) {
@@ -339,7 +334,7 @@ export class IvyProjectExplorer {
     return this.treeDataProvider.hasIvyProjects();
   }
 
-  private async getAddCommandSelectionContext(selection: TreeSelection) {
+  private async getAddCommandSelectionContext(selection: TreeSelection): Promise<AddCommandSelectionContext | undefined> {
     const hasIvyProjects = await this.hasIvyProjects();
     if (!hasIvyProjects) {
       logErrorMessage('No Axon Ivy projects in the workspace. Create an Axon Ivy project first.');
@@ -348,7 +343,7 @@ export class IvyProjectExplorer {
     const existingProjects = await this.getIvyProjects();
     const uri = await treeSelectionToUri(selection);
     const projectPath = uri ? await treeUriToProjectPath(uri, Promise.resolve(existingProjects)) : undefined;
-    return [existingProjects, uri, projectPath] as const;
+    return { existingIvyProjects: existingProjects, uriSelection: uri, projectPathSelection: projectPath };
   }
 
   static get instance() {
@@ -358,3 +353,8 @@ export class IvyProjectExplorer {
     throw new Error('IvyProjectExplorer has not been initialized');
   }
 }
+export type AddCommandSelectionContext = {
+  existingIvyProjects: string[];
+  uriSelection?: Uri | undefined;
+  projectPathSelection?: string | undefined;
+};

--- a/extension/src/project-explorer/new-case-map.ts
+++ b/extension/src/project-explorer/new-case-map.ts
@@ -1,43 +1,41 @@
 import path from 'path';
-import { Uri } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import { IvyEngineManager } from '../engine/engine-manager';
+import { type AddCommandSelectionContext } from './ivy-project-explorer';
 import {
   type InputStep,
   type MSStateBase,
   MultiStepCancelledError,
   MultiStepInput,
   MultiStepInvalidStateError,
-  type ProjectSelection
+  type ProjectSelection,
+  resolveAddCommandSelectionContext
 } from './utils/multi-step-input';
-import { resolveNamespaceFromPath, validateNamespace, validateProjectArtifactName } from './utils/util';
+import { validateNamespace, validateProjectArtifactName } from './utils/util';
 
 interface NewCaseMapState extends MSStateBase {
-  projectSelection?: ProjectSelection;
+  project?: ProjectSelection;
   name?: string;
   namespace?: string;
-  projectSelectionFromPath?: ProjectSelection;
+  projectFromSelection?: ProjectSelection;
 }
 
-export const addNewCaseMap = async (existingProjects: string[], uri?: Uri, projectPath?: string) => {
-  // If supplied, use preselected URI and project path for project and namespace
-  const projectSelectionFromPath = projectPath
-    ? { label: projectPath.substring(projectPath.lastIndexOf(path.sep) + 1), description: projectPath, path: projectPath }
-    : undefined;
-  const namespaceFromPath = projectPath && uri ? await resolveNamespaceFromPath(uri, projectPath, 'processes') : undefined;
+export const addNewCaseMap = async (selectionContext: AddCommandSelectionContext) => {
+  const existingProjects = selectionContext.existingIvyProjects;
+  const { projectFromSelection, namespaceFromSelection } = await resolveAddCommandSelectionContext(selectionContext, 'processes');
 
   const stepProject: InputStep<NewCaseMapState> = async (input: MultiStepInput<NewCaseMapState>, state: NewCaseMapState) => {
-    if (state.projectSelectionFromPath && state.projectSelection === undefined) {
-      state.projectSelection = state.projectSelectionFromPath;
-      state.projectSelectionFromPath = undefined;
+    if (state.projectFromSelection && state.project === undefined) {
+      state.project = state.projectFromSelection;
+      state.projectFromSelection = undefined;
     } else {
-      state.projectSelection = await input.showQuickPick({
+      state.project = await input.showQuickPick({
         title: state.dialogTitle,
         titleSuffix: ' - Choose project',
         placeholder: 'Select one of the available projects',
         currentStep: state.currentStep,
         totalSteps: state.totalSteps,
-        activeItem: state.projectSelection,
+        activeItem: state.project,
         items: existingProjects.map(project => {
           return {
             label: project.substring(project.lastIndexOf(path.sep) + 1),
@@ -85,8 +83,8 @@ export const addNewCaseMap = async (existingProjects: string[], uri?: Uri, proje
     dialogTitle: 'Add New Case Map',
     currentStep: 1,
     totalSteps: steps.length,
-    namespace: typeof namespaceFromPath === 'string' && namespaceFromPath.trim() !== '' ? namespaceFromPath : '',
-    projectSelectionFromPath: projectSelectionFromPath
+    namespace: typeof namespaceFromSelection === 'string' && namespaceFromSelection.trim() !== '' ? namespaceFromSelection : '',
+    projectFromSelection: projectFromSelection
   };
 
   try {
@@ -100,9 +98,9 @@ export const addNewCaseMap = async (existingProjects: string[], uri?: Uri, proje
     }
   }
 
-  if (newCaseMapData.name !== undefined && newCaseMapData.namespace !== undefined && newCaseMapData.projectSelection !== undefined) {
+  if (newCaseMapData.name !== undefined && newCaseMapData.namespace !== undefined && newCaseMapData.project !== undefined) {
     const createCaseMapInput = {
-      projectDir: newCaseMapData.projectSelection.path,
+      projectDir: newCaseMapData.project.path,
       name: newCaseMapData.name,
       namespace: newCaseMapData.namespace
     };

--- a/extension/src/project-explorer/new-case-map.ts
+++ b/extension/src/project-explorer/new-case-map.ts
@@ -2,7 +2,14 @@ import path from 'path';
 import { Uri } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import { IvyEngineManager } from '../engine/engine-manager';
-import { type InputStep, type MSStateBase, MultiStepCancelledError, MultiStepInput, type ProjectSelection } from './utils/multi-step-input';
+import {
+  type InputStep,
+  type MSStateBase,
+  MultiStepCancelledError,
+  MultiStepInput,
+  MultiStepInvalidStateError,
+  type ProjectSelection
+} from './utils/multi-step-input';
 import { resolveNamespaceFromPath, validateNamespace, validateProjectArtifactName } from './utils/util';
 
 interface NewCaseMapState extends MSStateBase {
@@ -45,7 +52,7 @@ export const addNewCaseMap = async (existingProjects: string[], uri?: Uri, proje
   const stepName: InputStep<NewCaseMapState> = async (input: MultiStepInput<NewCaseMapState>, state: NewCaseMapState) => {
     state.name = await input.showTextInput({
       title: state.dialogTitle,
-      titleSuffix: ' - Choose case map name',
+      titleSuffix: ' - Choose name',
       placeholder: 'Enter a name. Allowed characters: a-z, A-Z, 0-9, _',
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
@@ -60,7 +67,7 @@ export const addNewCaseMap = async (existingProjects: string[], uri?: Uri, proje
   const stepNamespace: InputStep<NewCaseMapState> = async (input: MultiStepInput<NewCaseMapState>, state: NewCaseMapState) => {
     state.namespace = await input.showTextInput({
       title: state.dialogTitle,
-      titleSuffix: ' - Choose case map namespace',
+      titleSuffix: ' - Choose namespace',
       placeholder: 'Enter Namespace separated by "/". Allowed characters: a-z, A-Z, 0-9, _, /',
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
@@ -102,6 +109,9 @@ export const addNewCaseMap = async (existingProjects: string[], uri?: Uri, proje
 
     await IvyEngineManager.instance.createCaseMap(createCaseMapInput);
   } else {
-    throw new Error('Case Map creation failed due to corrupted input state. Current input state: ' + JSON.stringify(newCaseMapData));
+    throw new MultiStepInvalidStateError(
+      'Case Map creation failed due to corrupted input state. name, namespace or project selection is undefined. Current input state: ' +
+        JSON.stringify(newCaseMapData)
+    );
   }
 };

--- a/extension/src/project-explorer/new-case-map.ts
+++ b/extension/src/project-explorer/new-case-map.ts
@@ -51,7 +51,7 @@ export const addNewCaseMap = async (selectionContext: AddCommandSelectionContext
     state.name = await input.showTextInput({
       title: state.dialogTitle,
       titleSuffix: ' - Choose name',
-      placeholder: 'Enter a name. Allowed characters: a-z, A-Z, 0-9, _',
+      placeholder: 'Enter a name. Must start with a letter or underscore. Allowed characters: a-z, A-Z, 0-9, _',
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
       value: state.name,

--- a/extension/src/project-explorer/new-data-class.ts
+++ b/extension/src/project-explorer/new-data-class.ts
@@ -114,6 +114,9 @@ export const addNewDataClass = async (type: DataClassType, existingProjects: str
       await IvyEngineManager.instance.createEntityClass(createDataClassInput);
     }
   } else {
-    throw new MultiStepInvalidStateError('Illegal state: name, namespace or project selection is undefined');
+    throw new MultiStepInvalidStateError(
+      'Data Class creation failed due to corrupted input state. name, namespace or project selection is undefined. Current input state: ' +
+        JSON.stringify(newDataClassDialogData)
+    );
   }
 };

--- a/extension/src/project-explorer/new-data-class.ts
+++ b/extension/src/project-explorer/new-data-class.ts
@@ -3,12 +3,14 @@ import { logErrorMessage } from '../base/logging-util';
 import { type DataClassInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
 import { type AddCommandSelectionContext } from './ivy-project-explorer';
-import type { InputStep, MSStateBase, ProjectSelection } from './utils/multi-step-input';
 import {
   MultiStepCancelledError,
   MultiStepInput,
   MultiStepInvalidStateError,
-  resolveAddCommandSelectionContext
+  resolveAddCommandSelectionContext,
+  type InputStep,
+  type MSStateBase,
+  type ProjectSelection
 } from './utils/multi-step-input';
 import { validateDotSeparatedName, validateProjectArtifactName } from './utils/util';
 

--- a/extension/src/project-explorer/new-data-class.ts
+++ b/extension/src/project-explorer/new-data-class.ts
@@ -56,7 +56,7 @@ export const addNewDataClass = async (type: DataClassType, selectionContext: Add
     state.name = await input.showTextInput({
       title: state.dialogTitle,
       titleSuffix: ' - Choose name',
-      placeholder: 'Enter a name. Allowed characters: a-z, A-Z, 0-9, _',
+      placeholder: 'Enter a name. Must start with a letter or underscore. Allowed characters: a-z, A-Z, 0-9, _',
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
       value: state.name,

--- a/extension/src/project-explorer/new-data-class.ts
+++ b/extension/src/project-explorer/new-data-class.ts
@@ -1,42 +1,44 @@
 import path from 'path';
-import { Uri } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import { type DataClassInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
+import { type AddCommandSelectionContext } from './ivy-project-explorer';
 import type { InputStep, MSStateBase, ProjectSelection } from './utils/multi-step-input';
-import { MultiStepCancelledError, MultiStepInput, MultiStepInvalidStateError } from './utils/multi-step-input';
-import { resolveNamespaceFromPath, validateDotSeparatedName, validateProjectArtifactName } from './utils/util';
+import {
+  MultiStepCancelledError,
+  MultiStepInput,
+  MultiStepInvalidStateError,
+  resolveAddCommandSelectionContext
+} from './utils/multi-step-input';
+import { validateDotSeparatedName, validateProjectArtifactName } from './utils/util';
 
 type DataClassType = 'Data Class' | 'Entity Class';
 
 type NewDataClassParams = DataClassInit;
 
 interface NewDataClassState extends MSStateBase {
-  projectSelection?: ProjectSelection | undefined;
+  project?: ProjectSelection | undefined;
   name?: string | undefined;
   namespace?: string | undefined;
-  projectSelectionFromPath?: ProjectSelection | undefined;
+  projectFromSelection?: ProjectSelection | undefined;
 }
 
-export const addNewDataClass = async (type: DataClassType, existingProjects: string[], uri?: Uri, projectPath?: string) => {
-  // If supplied, use preselected URI and project path for project and namespace
-  const projectSelectionFromPath = projectPath
-    ? { label: projectPath.substring(projectPath.lastIndexOf(path.sep) + 1), description: projectPath, path: projectPath }
-    : undefined;
-  const namespaceFromPath = projectPath && uri ? await resolveNamespaceFromPath(uri, projectPath, 'dataclasses') : undefined;
+export const addNewDataClass = async (type: DataClassType, selectionContext: AddCommandSelectionContext) => {
+  const existingProjects = selectionContext.existingIvyProjects;
+  const { projectFromSelection, namespaceFromSelection } = await resolveAddCommandSelectionContext(selectionContext, 'dataclasses');
 
   const stepProject: InputStep<NewDataClassState> = async (input: MultiStepInput<NewDataClassState>, state: NewDataClassState) => {
-    if (state.projectSelectionFromPath && state.projectSelection === undefined) {
-      state.projectSelection = state.projectSelectionFromPath;
-      state.projectSelectionFromPath = undefined;
+    if (state.projectFromSelection && state.project === undefined) {
+      state.project = state.projectFromSelection;
+      state.projectFromSelection = undefined;
     } else {
-      state.projectSelection = await input.showQuickPick<ProjectSelection>({
+      state.project = await input.showQuickPick<ProjectSelection>({
         title: state.dialogTitle,
         titleSuffix: ' - Choose project',
         placeholder: 'Select one of the available projects',
         currentStep: state.currentStep,
         totalSteps: state.totalSteps,
-        activeItem: state.projectSelection,
+        activeItem: state.project,
         items: existingProjects.map(project => {
           return {
             label: project.substring(project.lastIndexOf(path.sep) + 1),
@@ -84,8 +86,8 @@ export const addNewDataClass = async (type: DataClassType, existingProjects: str
     dialogTitle: `Add New ${type}`,
     currentStep: 1,
     totalSteps: steps.length,
-    namespace: typeof namespaceFromPath === 'string' && namespaceFromPath.trim() !== '' ? namespaceFromPath : undefined,
-    projectSelectionFromPath: projectSelectionFromPath
+    namespace: typeof namespaceFromSelection === 'string' && namespaceFromSelection.trim() !== '' ? namespaceFromSelection : undefined,
+    projectFromSelection: projectFromSelection
   };
 
   try {
@@ -102,11 +104,11 @@ export const addNewDataClass = async (type: DataClassType, existingProjects: str
   if (
     newDataClassDialogData.name !== undefined &&
     newDataClassDialogData.namespace !== undefined &&
-    newDataClassDialogData.projectSelection !== undefined
+    newDataClassDialogData.project !== undefined
   ) {
     const createDataClassInput: NewDataClassParams = {
       name: `${newDataClassDialogData.namespace}.${newDataClassDialogData.name}`,
-      projectDir: newDataClassDialogData.projectSelection.path
+      projectDir: newDataClassDialogData.project.path
     };
     if (type === 'Data Class') {
       await IvyEngineManager.instance.createDataClass(createDataClassInput);

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -56,7 +56,7 @@ export const addNewProcess = async (selectionContext: AddCommandSelectionContext
     state.name = await input.showTextInput({
       title: state.dialogTitle,
       titleSuffix: ' - Choose name',
-      placeholder: 'Enter a name. Allowed characters: a-z, A-Z, 0-9, _',
+      placeholder: 'Enter a name. Must start with a letter or underscore. Allowed characters: a-z, A-Z, 0-9, _',
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
       value: state.name,

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -3,7 +3,14 @@ import { Uri } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import type { ProcessInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
-import { type InputStep, type MSStateBase, MultiStepCancelledError, MultiStepInput, type ProjectSelection } from './utils/multi-step-input';
+import {
+  type InputStep,
+  type MSStateBase,
+  MultiStepCancelledError,
+  MultiStepInput,
+  MultiStepInvalidStateError,
+  type ProjectSelection
+} from './utils/multi-step-input';
 import { resolveNamespaceFromPath, validateNamespace, validateProjectArtifactName } from './utils/util';
 
 export type ProcessKind = 'Business Process' | 'Callable Sub Process' | 'Web Service Process' | '';
@@ -11,10 +18,10 @@ export type ProcessKind = 'Business Process' | 'Callable Sub Process' | 'Web Ser
 export type NewProcessParams = ProcessInit;
 
 interface NewProcessState extends MSStateBase {
-  projectSelection: ProjectSelection;
-  name: string;
-  namespace: string;
-  projectSelectionFromPath?: ProjectSelection;
+  projectSelection?: ProjectSelection | undefined;
+  name?: string | undefined;
+  namespace?: string | undefined;
+  projectSelectionFromPath?: ProjectSelection | undefined;
 }
 
 export const addNewProcess = async (
@@ -32,7 +39,7 @@ export const addNewProcess = async (
   const namespaceFromPath = projectPath && uri ? await resolveNamespaceFromPath(uri, projectPath, 'processes') : undefined;
 
   const stepProject: InputStep<NewProcessState> = async (input: MultiStepInput<NewProcessState>, state: NewProcessState) => {
-    if (state.projectSelectionFromPath && (state.projectSelection.label === '' || state.projectSelection.label === undefined)) {
+    if (state.projectSelectionFromPath && state.projectSelection === undefined) {
       state.projectSelection = state.projectSelectionFromPath;
       state.projectSelectionFromPath = undefined;
     } else {
@@ -58,7 +65,7 @@ export const addNewProcess = async (
   const stepName: InputStep<NewProcessState> = async (input: MultiStepInput<NewProcessState>, state: NewProcessState) => {
     state.name = await input.showTextInput({
       title: state.dialogTitle,
-      titleSuffix: ' - Choose process name',
+      titleSuffix: ' - Choose name',
       placeholder: 'Enter a name. Allowed characters: a-z, A-Z, 0-9, _',
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
@@ -74,7 +81,7 @@ export const addNewProcess = async (
   const stepNamespace: InputStep<NewProcessState> = async (input: MultiStepInput<NewProcessState>, state: NewProcessState) => {
     state.namespace = await input.showTextInput({
       title: state.dialogTitle,
-      titleSuffix: ' - Choose process namespace',
+      titleSuffix: ' - Choose namespace',
       placeholder: 'Enter Namespace separated by "/". Allowed characters: a-z, A-Z, 0-9, _, /',
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
@@ -93,9 +100,7 @@ export const addNewProcess = async (
     dialogTitle: `Add New ${kind}`,
     currentStep: 1,
     totalSteps: steps.length,
-    name: '',
     namespace: typeof namespaceFromPath === 'string' && namespaceFromPath.trim() !== '' ? namespaceFromPath : '',
-    projectSelection: {} as ProjectSelection,
     projectSelectionFromPath: projectSelectionFromPath
   };
 
@@ -110,7 +115,7 @@ export const addNewProcess = async (
     }
   }
 
-  if (newProcessData.projectSelection && newProcessData.name) {
+  if (newProcessData.projectSelection != undefined && newProcessData.name !== undefined && newProcessData.namespace !== undefined) {
     const createProcessInput: NewProcessParams = {
       name: newProcessData.name,
       namespace: newProcessData.namespace,
@@ -121,6 +126,8 @@ export const addNewProcess = async (
 
     await IvyEngineManager.instance.createProcess(createProcessInput);
   } else {
-    throw new Error('Process creation failed due to corrupted input state. Current input state: ' + JSON.stringify(newProcessData));
+    throw new MultiStepInvalidStateError(
+      'Process creation failed due to corrupted input state. Current input state: ' + JSON.stringify(newProcessData)
+    );
   }
 };

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -1,55 +1,46 @@
 import path from 'path';
-import { Uri } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import type { ProcessInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
+import { type AddCommandSelectionContext } from './ivy-project-explorer';
 import {
-  type InputStep,
-  type MSStateBase,
   MultiStepCancelledError,
   MultiStepInput,
   MultiStepInvalidStateError,
+  resolveAddCommandSelectionContext,
+  type InputStep,
+  type MSStateBase,
   type ProjectSelection
 } from './utils/multi-step-input';
-import { resolveNamespaceFromPath, validateNamespace, validateProjectArtifactName } from './utils/util';
+import { validateNamespace, validateProjectArtifactName } from './utils/util';
 
 export type ProcessKind = 'Business Process' | 'Callable Sub Process' | 'Web Service Process' | '';
 
 export type NewProcessParams = ProcessInit;
 
 interface NewProcessState extends MSStateBase {
-  projectSelection?: ProjectSelection | undefined;
+  project?: ProjectSelection | undefined;
   name?: string | undefined;
   namespace?: string | undefined;
-  projectSelectionFromPath?: ProjectSelection | undefined;
+  projectFromSelection?: ProjectSelection | undefined;
 }
 
-export const addNewProcess = async (
-  kind: ProcessKind = 'Business Process',
-  existingProjects: string[],
-  pid?: string,
-  uri?: Uri,
-  projectPath?: string
-) => {
-  // Step 1 - Pick the project to create the process in, based on available projects in the workspace
-  // If supplied, use preselected URI and project path for project and namespace
-  const projectSelectionFromPath = projectPath
-    ? { label: projectPath.substring(projectPath.lastIndexOf(path.sep) + 1), description: projectPath, path: projectPath }
-    : undefined;
-  const namespaceFromPath = projectPath && uri ? await resolveNamespaceFromPath(uri, projectPath, 'processes') : undefined;
+export const addNewProcess = async (selectionContext: AddCommandSelectionContext, kind: ProcessKind = 'Business Process', pid?: string) => {
+  const existingProjects = selectionContext.existingIvyProjects;
+  const { projectFromSelection, namespaceFromSelection } = await resolveAddCommandSelectionContext(selectionContext, 'processes');
 
   const stepProject: InputStep<NewProcessState> = async (input: MultiStepInput<NewProcessState>, state: NewProcessState) => {
-    if (state.projectSelectionFromPath && state.projectSelection === undefined) {
-      state.projectSelection = state.projectSelectionFromPath;
-      state.projectSelectionFromPath = undefined;
+    if (state.projectFromSelection && state.project === undefined) {
+      state.project = state.projectFromSelection;
+      state.projectFromSelection = undefined;
     } else {
-      state.projectSelection = await input.showQuickPick({
+      state.project = await input.showQuickPick({
         title: state.dialogTitle,
         titleSuffix: ' - Choose project',
         placeholder: 'Select one of the available projects',
         currentStep: state.currentStep,
         totalSteps: state.totalSteps,
-        activeItem: state.projectSelection,
+        activeItem: state.project,
         items: existingProjects.map(project => {
           return {
             label: project.substring(project.lastIndexOf(path.sep) + 1),
@@ -61,7 +52,6 @@ export const addNewProcess = async (
     }
   };
 
-  // Step 2 - Enter the name of the process to be created
   const stepName: InputStep<NewProcessState> = async (input: MultiStepInput<NewProcessState>, state: NewProcessState) => {
     state.name = await input.showTextInput({
       title: state.dialogTitle,
@@ -77,7 +67,6 @@ export const addNewProcess = async (
     });
   };
 
-  // Step 3 - Enter the namespace of the process to be created
   const stepNamespace: InputStep<NewProcessState> = async (input: MultiStepInput<NewProcessState>, state: NewProcessState) => {
     state.namespace = await input.showTextInput({
       title: state.dialogTitle,
@@ -100,8 +89,8 @@ export const addNewProcess = async (
     dialogTitle: `Add New ${kind}`,
     currentStep: 1,
     totalSteps: steps.length,
-    namespace: typeof namespaceFromPath === 'string' && namespaceFromPath.trim() !== '' ? namespaceFromPath : '',
-    projectSelectionFromPath: projectSelectionFromPath
+    namespace: typeof namespaceFromSelection === 'string' && namespaceFromSelection.trim() !== '' ? namespaceFromSelection : '',
+    projectFromSelection: projectFromSelection
   };
 
   try {
@@ -115,11 +104,11 @@ export const addNewProcess = async (
     }
   }
 
-  if (newProcessData.projectSelection != undefined && newProcessData.name !== undefined && newProcessData.namespace !== undefined) {
+  if (newProcessData.project != undefined && newProcessData.name !== undefined && newProcessData.namespace !== undefined) {
     const createProcessInput: NewProcessParams = {
       name: newProcessData.name,
       namespace: newProcessData.namespace,
-      path: newProcessData.projectSelection.path,
+      path: newProcessData.project.path,
       kind,
       pid
     };

--- a/extension/src/project-explorer/new-project.ts
+++ b/extension/src/project-explorer/new-project.ts
@@ -3,7 +3,13 @@ import { Uri } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import type { NewProjectParams } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
-import { type InputStep, type MSStateBase, MultiStepCancelledError, MultiStepInput } from './utils/multi-step-input';
+import {
+  type InputStep,
+  type MSStateBase,
+  MultiStepCancelledError,
+  MultiStepInput,
+  MultiStepInvalidStateError
+} from './utils/multi-step-input';
 import { validateDotSeparatedName, validateProjectName } from './utils/util';
 
 interface NewProjectState extends MSStateBase {
@@ -112,6 +118,8 @@ export const addNewProject = async (selectedUri: Uri) => {
     };
     await IvyEngineManager.instance.createProject(createProjectInput);
   } else {
-    throw new Error('Project creation failed due to corrupted input state. Current input state: ' + JSON.stringify(newProjectData));
+    throw new MultiStepInvalidStateError(
+      'Project creation failed due to corrupted input state. Current input state: ' + JSON.stringify(newProjectData)
+    );
   }
 };

--- a/extension/src/project-explorer/new-user-dialog.ts
+++ b/extension/src/project-explorer/new-user-dialog.ts
@@ -4,12 +4,14 @@ import { logErrorMessage } from '../base/logging-util';
 import type { HdInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
 import { type AddCommandSelectionContext } from './ivy-project-explorer';
-import type { InputStep, MSStateBase, ProjectSelection } from './utils/multi-step-input';
 import {
   MultiStepCancelledError,
   MultiStepInput,
   MultiStepInvalidStateError,
-  resolveAddCommandSelectionContext
+  resolveAddCommandSelectionContext,
+  type InputStep,
+  type MSStateBase,
+  type ProjectSelection
 } from './utils/multi-step-input';
 import { validateDotSeparatedName, validateProjectArtifactName } from './utils/util';
 

--- a/extension/src/project-explorer/new-user-dialog.ts
+++ b/extension/src/project-explorer/new-user-dialog.ts
@@ -1,11 +1,17 @@
 import path from 'path';
-import { Uri, type QuickPickItem } from 'vscode';
+import { type QuickPickItem } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import type { HdInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
+import { type AddCommandSelectionContext } from './ivy-project-explorer';
 import type { InputStep, MSStateBase, ProjectSelection } from './utils/multi-step-input';
-import { MultiStepCancelledError, MultiStepInput, MultiStepInvalidStateError } from './utils/multi-step-input';
-import { resolveNamespaceFromPath, validateDotSeparatedName, validateProjectArtifactName } from './utils/util';
+import {
+  MultiStepCancelledError,
+  MultiStepInput,
+  MultiStepInvalidStateError,
+  resolveAddCommandSelectionContext
+} from './utils/multi-step-input';
+import { validateDotSeparatedName, validateProjectArtifactName } from './utils/util';
 
 export const dialogTypes = ['JSF', 'Form', 'JSFOffline'] as const;
 export type DialogType = (typeof dialogTypes)[number];
@@ -32,19 +38,19 @@ interface TemplatePick extends QuickPickItem {
 export type NewUserDialogParams = HdInit;
 
 interface NewUserDialogState extends MSStateBase {
-  projectSelection?: ProjectSelection | undefined;
+  project?: ProjectSelection | undefined;
   name?: string | undefined;
   namespace?: string | undefined;
   layout?: LayoutPick | undefined;
   template?: TemplatePick | undefined;
-  projectSelectionFromPath?: ProjectSelection | undefined;
+  projectFromSelection?: ProjectSelection | undefined;
 }
 
 const prepareAndValidateFinalState: (
   type: DialogType,
   state: NewUserDialogState
 ) => asserts state is NewUserDialogState & {
-  projectSelection: ProjectSelection;
+  project: ProjectSelection;
   name: string;
   namespace: string;
   layout: LayoutPick | undefined;
@@ -52,7 +58,7 @@ const prepareAndValidateFinalState: (
 } = (type, state) => {
   const ERROR_PREFIX = 'Invalid final input. Cannot create Dialog: ';
 
-  if (state.projectSelection === undefined) {
+  if (state.project === undefined) {
     throw new MultiStepInvalidStateError(ERROR_PREFIX + 'Project selection cannot be null.');
   }
   if (state.name === undefined) {
@@ -90,25 +96,22 @@ const prepareAndValidateFinalState: (
   }
 };
 
-export const addNewUserDialog = async (type: DialogType, existingProjects: string[], pid?: string, uri?: Uri, projectPath?: string) => {
-  // If supplied, use preselected URI and project path for project and namespace
-  const projectSelectionFromPath = projectPath
-    ? { label: projectPath.substring(projectPath.lastIndexOf(path.sep) + 1), description: projectPath, path: projectPath }
-    : undefined;
-  const namespaceFromPath = projectPath && uri ? await resolveNamespaceFromPath(uri, projectPath, 'src_hd') : undefined;
+export const addNewUserDialog = async (selectionContext: AddCommandSelectionContext, type: DialogType, pid?: string) => {
+  const existingProjects = selectionContext.existingIvyProjects;
+  const { projectFromSelection, namespaceFromSelection } = await resolveAddCommandSelectionContext(selectionContext, 'src_hd');
 
   const stepProject: InputStep<NewUserDialogState> = async (input: MultiStepInput<NewUserDialogState>, state: NewUserDialogState) => {
-    if (state.projectSelectionFromPath && state.projectSelection === undefined) {
-      state.projectSelection = state.projectSelectionFromPath;
-      state.projectSelectionFromPath = undefined;
+    if (state.projectFromSelection && state.project === undefined) {
+      state.project = state.projectFromSelection;
+      state.projectFromSelection = undefined;
     } else {
-      state.projectSelection = await input.showQuickPick<ProjectSelection>({
+      state.project = await input.showQuickPick<ProjectSelection>({
         title: state.dialogTitle,
         titleSuffix: ' - Choose project',
         placeholder: 'Select one of the available projects',
         currentStep: state.currentStep,
         totalSteps: state.totalSteps,
-        activeItem: state.projectSelection,
+        activeItem: state.project,
         items: existingProjects.map(project => {
           return {
             label: project.substring(project.lastIndexOf(path.sep) + 1),
@@ -203,8 +206,8 @@ export const addNewUserDialog = async (type: DialogType, existingProjects: strin
     dialogTitle: `Add New ${type}`,
     currentStep: 1,
     totalSteps: steps.length,
-    namespace: typeof namespaceFromPath === 'string' && namespaceFromPath.trim() !== '' ? namespaceFromPath : undefined,
-    projectSelectionFromPath: projectSelectionFromPath
+    namespace: typeof namespaceFromSelection === 'string' && namespaceFromSelection.trim() !== '' ? namespaceFromSelection : undefined,
+    projectFromSelection: projectFromSelection
   };
 
   try {
@@ -224,7 +227,7 @@ export const addNewUserDialog = async (type: DialogType, existingProjects: strin
     type,
     name: newUserDialogData.name,
     namespace: newUserDialogData.namespace,
-    projectDir: newUserDialogData.projectSelection.path,
+    projectDir: newUserDialogData.project.path,
     pid,
     layout: newUserDialogData.layout?.label,
     template: newUserDialogData.template?.label

--- a/extension/src/project-explorer/new-user-dialog.ts
+++ b/extension/src/project-explorer/new-user-dialog.ts
@@ -127,7 +127,7 @@ export const addNewUserDialog = async (selectionContext: AddCommandSelectionCont
     state.name = await input.showTextInput({
       title: state.dialogTitle,
       titleSuffix: ' - Choose name',
-      placeholder: 'Enter a name. Allowed characters: a-z, A-Z, 0-9, _',
+      placeholder: 'Enter a name. Must start with a letter or underscore. Allowed characters: a-z, A-Z, 0-9, _',
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
       value: state.name,

--- a/extension/src/project-explorer/new-user-dialog.ts
+++ b/extension/src/project-explorer/new-user-dialog.ts
@@ -123,7 +123,7 @@ export const addNewUserDialog = async (type: DialogType, existingProjects: strin
   const stepName: InputStep<NewUserDialogState> = async (input: MultiStepInput<NewUserDialogState>, state: NewUserDialogState) => {
     state.name = await input.showTextInput({
       title: state.dialogTitle,
-      titleSuffix: ' - Choose dialog name',
+      titleSuffix: ' - Choose name',
       placeholder: 'Enter a name. Allowed characters: a-z, A-Z, 0-9, _',
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,
@@ -138,7 +138,7 @@ export const addNewUserDialog = async (type: DialogType, existingProjects: strin
   const stepNamespace: InputStep<NewUserDialogState> = async (input: MultiStepInput<NewUserDialogState>, state: NewUserDialogState) => {
     state.namespace = await input.showTextInput({
       title: state.dialogTitle,
-      titleSuffix: ' - Choose dialog namespace',
+      titleSuffix: ' - Choose namespace',
       placeholder: 'Enter Namespace separated by ".". Allowed characters: a-z, A-Z, 0-9, _, .',
       currentStep: state.currentStep,
       totalSteps: state.totalSteps,

--- a/extension/src/project-explorer/utils/multi-step-input.ts
+++ b/extension/src/project-explorer/utils/multi-step-input.ts
@@ -1,5 +1,8 @@
+import path from 'path';
 import type { QuickInput, QuickPickItem } from 'vscode';
 import { Disposable, QuickInputButtons, window } from 'vscode';
+import { type AddCommandSelectionContext } from '../ivy-project-explorer';
+import { resolveNamespaceFromPath, type ResourceDirectoryTarget } from './util';
 
 export class MultiStepCancelledError extends Error {
   constructor(message: string) {
@@ -31,6 +34,29 @@ export interface ProjectSelection extends QuickPickItem {
   description: string;
   path: string;
 }
+
+export const resolveAddCommandSelectionContext = async (
+  selectionContext: AddCommandSelectionContext,
+  resourceDirectoryTarget: ResourceDirectoryTarget
+): Promise<{
+  projectFromSelection: ProjectSelection | undefined;
+  namespaceFromSelection: string | undefined;
+}> => {
+  const { projectPathSelection: projectPathFromSelection, uriSelection: uriFromSelection } = selectionContext;
+  if (!projectPathFromSelection || projectPathFromSelection === '') {
+    return { projectFromSelection: undefined, namespaceFromSelection: undefined };
+  }
+  const projectFromSelection: ProjectSelection = {
+    label: projectPathFromSelection.substring(projectPathFromSelection.lastIndexOf(path.sep) + 1),
+    description: projectPathFromSelection,
+    path: projectPathFromSelection
+  };
+  if (!uriFromSelection) {
+    return { projectFromSelection: projectFromSelection, namespaceFromSelection: undefined };
+  }
+  const namespaceFromSelection = await resolveNamespaceFromPath(uriFromSelection, projectPathFromSelection, resourceDirectoryTarget);
+  return { projectFromSelection, namespaceFromSelection };
+};
 
 export type InputStep<T extends MSStateBase> = (input: MultiStepInput<T>, state: T) => Thenable<InputStep<T>> | Promise<void>;
 

--- a/extension/src/project-explorer/utils/util.test.ts
+++ b/extension/src/project-explorer/utils/util.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest';
-import { validateDotSeparatedName, validateNamespace } from './util';
+import { validateDotSeparatedName, validateNamespace, validateProjectArtifactName } from './util';
 
 vi.mock('vscode', () => ({
   FileType: { File: 1, Directory: 2 },
@@ -109,4 +109,76 @@ test('namespace error hyphens', () => {
 
 test('namespace error dot-separated input', () => {
   expect(validateNamespace('com.example')).toBeTruthy();
+});
+
+test('project artifact name valid single letter', () => {
+  expect(validateProjectArtifactName('a')).toBeUndefined();
+});
+
+test('project artifact name valid underscore', () => {
+  expect(validateProjectArtifactName('_')).toBeUndefined();
+});
+
+test('project artifact name valid single uppercase letter', () => {
+  expect(validateProjectArtifactName('A')).toBeUndefined();
+});
+
+test('project artifact name valid one word', () => {
+  expect(validateProjectArtifactName('oneWord')).toBeUndefined();
+});
+
+test('project artifact name valid one word with underscore', () => {
+  expect(validateProjectArtifactName('oneWord_underscore')).toBeUndefined();
+});
+
+test('project artifact name valid leading underscore', () => {
+  expect(validateProjectArtifactName('_leadingUnderscore')).toBeUndefined();
+});
+
+test('project artifact name valid double leading underscore', () => {
+  expect(validateProjectArtifactName('__doubleLeadingUnderscore')).toBeUndefined();
+});
+
+test('project artifact name valid trailing underscore', () => {
+  expect(validateProjectArtifactName('trailingUnderscore_')).toBeUndefined();
+});
+
+test('project artifact name valid double trailing underscore', () => {
+  expect(validateProjectArtifactName('doubleTrailingUnderscore__')).toBeUndefined();
+});
+
+test('project artifact name valid both underscore', () => {
+  expect(validateProjectArtifactName('_bothUnderscore_')).toBeUndefined();
+});
+
+test('project artifact name valid both double underscore', () => {
+  expect(validateProjectArtifactName('__bothDoubleUnderscore__')).toBeUndefined();
+});
+
+test('project artifact name valid multiple underscore', () => {
+  expect(validateProjectArtifactName('_multiple__underscore_')).toBeUndefined();
+});
+
+test('project artifact name valid digit second place', () => {
+  expect(validateProjectArtifactName('d1igitSecondPlace')).toBeUndefined();
+});
+
+test('project artifact name valid digit last place', () => {
+  expect(validateProjectArtifactName('digitLastPlace9')).toBeUndefined();
+});
+
+test('project artifact name invalid empty', () => {
+  expect(validateProjectArtifactName('')).toBeTruthy();
+});
+
+test('project artifact name invalid leading digit', () => {
+  expect(validateProjectArtifactName('1leadingDigit')).toBeTruthy();
+});
+
+test('project artifact name invalid leading whitespace', () => {
+  expect(validateProjectArtifactName(' leadingWhitespace')).toBeTruthy();
+});
+
+test('project artifact name invalid trailing whitespace', () => {
+  expect(validateProjectArtifactName('trailingWhitespace ')).toBeTruthy();
 });

--- a/extension/src/project-explorer/utils/util.ts
+++ b/extension/src/project-explorer/utils/util.ts
@@ -81,7 +81,7 @@ export const validateProjectArtifactName = (value: string) => {
   if (pattern.test(value)) {
     return;
   }
-  return 'Only letters, numbers, and underscores are allowed -- No spaces -- Cannot be empty';
+  return 'Only letters, numbers, and underscores are allowed -- Must start with a letter or underscore -- No spaces -- Cannot be empty';
 };
 
 export const validateProjectName = (value: string) => {

--- a/extension/src/project-explorer/utils/util.ts
+++ b/extension/src/project-explorer/utils/util.ts
@@ -77,7 +77,7 @@ export const getWorkspaceFolder = async () => {
 };
 
 export const validateProjectArtifactName = (value: string) => {
-  const pattern = /^[\w]+$/;
+  const pattern = /^[a-zA-Z_][\w]*$/;
   if (pattern.test(value)) {
     return;
   }

--- a/extension/src/project-explorer/utils/util.ts
+++ b/extension/src/project-explorer/utils/util.ts
@@ -17,7 +17,7 @@ const defaultNamespaceOf = (projecDir: string) => {
   );
 };
 
-type ResourceDirectoryTarget = 'processes' | 'src_hd' | 'dataclasses';
+export type ResourceDirectoryTarget = 'processes' | 'src_hd' | 'dataclasses';
 
 export const resolveNamespaceFromPath = async (selectedUri: Uri, projectDir: string, target: ResourceDirectoryTarget) => {
   let fileStat: FileStat;


### PR DESCRIPTION
- `validateProjectArtifactName` no longer allows a leading digit, will lead to error
  - https://axon-ivy.atlassian.net/browse/XIVY-18903
- new-*.ts have homogenous titles and error messages
- `ivy-project-explorer` has a new helper `getAddCommandSelectionContext` and type `AddCommandSelectionContext`.
  - Gathers context (existing projects, selection uri and selection projectPath) used in multiple commands adding project artifacts
  - `multi-step-input.ts` uses type `AddCommandSelectionContext` to provide a function `resolveAddCommandSelectionContext` which resolves the context into project and namespace pre selection. This is used by multi-step dialogs `new-process.ts`, `new-data-class.ts`, `new-user-dialog.ts`, `new-case-map.ts`.
- Simplify and clarify MSState property naming in `new-process.ts`, `new-data-class.ts`, `new-user-dialog.ts`, `new-case-map.ts`.
  - `projectSelection` is now `project`
  - `projectSelectionFromPath` is now `projectFromSelection` from the selection context
  - `namespaceFromPath` is now `namespaceFromSelection` from the selection context