### PR TITLE
Fix codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @ivy-lmu
-* @ivy-dar
+* @ivy-lmu @ivy-dar


### PR DESCRIPTION
<img width="345" height="93" alt="image" src="https://github.com/user-attachments/assets/694ada48-604e-4214-b93d-e6e40822ddc0" />
otherwise only ivy-dar is reviewer per default