### PR TITLE
XIVY-18776 create project when no workspace open

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -837,6 +837,11 @@
         "view": "ivyProjects",
         "contents": "You have not yet opened a folder.\n[Open Folder](command:vscode.openFolder)",
         "when": "workbenchState == empty"
+      },
+      {
+        "view": "ivyProjects",
+        "contents": "There are no Axon Ivy projects. Create one by clicking the button below.\n[Create Axon Ivy Project](command:ivyProjects.addNewProject)",
+        "when": "workbenchState != empty && !ivy:hasIvyProjects && ivy:isStarted"
       }
     ]
   }

--- a/extension/src/engine/engine-manager.ts
+++ b/extension/src/engine/engine-manager.ts
@@ -105,6 +105,7 @@ export class IvyEngineManager {
       return;
     }
     this.started = true;
+    await IvyProjectExplorer.instance.setProjectExplorerContext({ isStarted: true });
     const engineUrl = await this.resolveEngineUrl();
     this.ivyEngineApi = new IvyEngineApi(engineUrl.toString());
     let devContextPath = await this.ivyEngineApi.devContextPath;
@@ -191,7 +192,7 @@ export class IvyEngineManager {
   }
 
   public async createProject(newProjectParams: NewProjectParams & { path: string }) {
-    await IvyProjectExplorer.instance.setProjectExplorerActivationCondition(true);
+    await IvyProjectExplorer.instance.setProjectExplorerContext({ hasIvyProjects: true });
     if (!this.started) {
       await this.start();
     }

--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -56,6 +56,10 @@ export class IvyProjectExplorer {
   private async activateEngineIfNeeded() {
     const hasIvyProjects = await this.hasIvyProjects();
     await this.setProjectExplorerContext({ hasIvyProjects: hasIvyProjects });
+    const workspaceHasOpenFolders = workspace.workspaceFolders && workspace.workspaceFolders.length > 0;
+    if (!workspaceHasOpenFolders) {
+      return;
+    }
     await IvyEngineManager.instance.start();
   }
 

--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -55,10 +55,8 @@ export class IvyProjectExplorer {
 
   private async activateEngineIfNeeded() {
     const hasIvyProjects = await this.hasIvyProjects();
-    await this.setProjectExplorerContext({ hasIvyProjects: true });
-    if (hasIvyProjects) {
-      await IvyEngineManager.instance.start();
-    }
+    await this.setProjectExplorerContext({ hasIvyProjects: hasIvyProjects });
+    await IvyEngineManager.instance.start();
   }
 
   private registerCommands(context: ExtensionContext) {

--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -55,7 +55,7 @@ export class IvyProjectExplorer {
 
   private async activateEngineIfNeeded() {
     const hasIvyProjects = await this.hasIvyProjects();
-    await this.setProjectExplorerActivationCondition(hasIvyProjects);
+    await this.setProjectExplorerContext({ hasIvyProjects: true });
     if (hasIvyProjects) {
       await IvyEngineManager.instance.start();
     }
@@ -285,8 +285,13 @@ export class IvyProjectExplorer {
     await addNewDataClass('Entity Class', addCommandContext);
   }
 
-  public async setProjectExplorerActivationCondition(hasIvyProjects: boolean) {
-    await executeCommand('setContext', 'ivy:hasIvyProjects', hasIvyProjects);
+  public async setProjectExplorerContext({ hasIvyProjects, isStarted }: { hasIvyProjects?: boolean; isStarted?: boolean }) {
+    if (hasIvyProjects !== undefined) {
+      await executeCommand('setContext', 'ivy:hasIvyProjects', hasIvyProjects);
+    }
+    if (isStarted !== undefined) {
+      await executeCommand('setContext', 'ivy:isStarted', isStarted);
+    }
   }
 
   public async selectCmsEntry(projectPath: string) {

--- a/playwright/tests/integration/engine.spec.ts
+++ b/playwright/tests/integration/engine.spec.ts
@@ -4,7 +4,8 @@ import { OutputView } from '../page-objects/output-view';
 import { SettingsView } from '../page-objects/settings-view';
 import { embeddedEngineWorkspace, noEngineWorkspacePath, noProjectWorkspacePath } from '../workspaces/workspace';
 
-test.describe('Engine run by extension', () => {
+// eslint-disable-next-line playwright/no-focused-test
+test.describe.only('Engine run by extension', () => {
   test.use({ workspace: embeddedEngineWorkspace });
 
   test('check if extension can download and start engine', async ({ page }) => {
@@ -19,7 +20,7 @@ test.describe('Engine run by extension', () => {
 test.describe('Engine noProjectWorkspacePath', () => {
   test.use({ workspace: noProjectWorkspacePath });
 
-  test('check default engine settings and ensure engine is not started due to missing project file', async ({ page }) => {
+  test('check default engine settings and ensure engine is started even if no projects in workspace', async ({ page }) => {
     const settingsView = new SettingsView(page);
     await settingsView.openDefaultSettings();
     await settingsView.containsSetting('"axonivy.engine.runByExtension": true');
@@ -33,7 +34,7 @@ test.describe('Engine noProjectWorkspacePath', () => {
     await settingsView.openWorkspaceSettings();
     await settingsView.containsSetting('"axonivy.engine.runByExtension": true');
     const outputview = new OutputView(page);
-    await expect(outputview.viewLocator).toBeHidden();
+    await outputview.checkIfEngineStarted();
   });
 
   test('switch release train', async ({ page }) => {

--- a/playwright/tests/integration/engine.spec.ts
+++ b/playwright/tests/integration/engine.spec.ts
@@ -4,8 +4,7 @@ import { OutputView } from '../page-objects/output-view';
 import { SettingsView } from '../page-objects/settings-view';
 import { embeddedEngineWorkspace, noEngineWorkspacePath, noProjectWorkspacePath } from '../workspaces/workspace';
 
-// eslint-disable-next-line playwright/no-focused-test
-test.describe.only('Engine run by extension', () => {
+test.describe('Engine run by extension', () => {
   test.use({ workspace: embeddedEngineWorkspace });
 
   test('check if extension can download and start engine', async ({ page }) => {


### PR DESCRIPTION
**When no workspace is open**
- Axon Ivy Projects - Treeview shows "Open Folder" option like the File Explorer Treeview

 **When a workspace is but no projects present**
- Axon Ivy Projects - Treeview shows "Create Axon Ivy Project" instead of blank
- Introduce new context key `isStarted` that complements `hasIvyProjects`
- Rename helper function `setProjectExplorerActivationCondition` to `setProjectExplorerContext`
- `IvyEngineManager.start()` is called regardless of `hasIvyProjects`. This means the engine will start even if no projects are present in the workspace. This allows for the "Create Axon Ivy Project" button without having a project already present in the workspace.
- The engine will only be started when any folder in the workspace is open
- Adjust test, now tests for a running engine in a workspace without a project