### PR TITLE
XIVY-18937 set default project namespace after project selection

### DIFF
--- a/extension/src/project-explorer/new-case-map.ts
+++ b/extension/src/project-explorer/new-case-map.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { Uri } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import { IvyEngineManager } from '../engine/engine-manager';
 import { type AddCommandSelectionContext } from './ivy-project-explorer';
@@ -11,7 +12,7 @@ import {
   type ProjectSelection,
   resolveAddCommandSelectionContext
 } from './utils/multi-step-input';
-import { validateNamespace, validateProjectArtifactName } from './utils/util';
+import { resolveNamespaceFromPath, type ResourceDirectoryTarget, validateNamespace, validateProjectArtifactName } from './utils/util';
 
 interface NewCaseMapState extends MSStateBase {
   project?: ProjectSelection;
@@ -21,8 +22,12 @@ interface NewCaseMapState extends MSStateBase {
 }
 
 export const addNewCaseMap = async (selectionContext: AddCommandSelectionContext) => {
+  const resourceDirectoryTarget: ResourceDirectoryTarget = 'processes';
   const existingProjects = selectionContext.existingIvyProjects;
-  const { projectFromSelection, namespaceFromSelection } = await resolveAddCommandSelectionContext(selectionContext, 'processes');
+  const { projectFromSelection, namespaceFromSelection } = await resolveAddCommandSelectionContext(
+    selectionContext,
+    resourceDirectoryTarget
+  );
 
   const stepProject: InputStep<NewCaseMapState> = async (input: MultiStepInput<NewCaseMapState>, state: NewCaseMapState) => {
     if (state.projectFromSelection && state.project === undefined) {
@@ -44,6 +49,16 @@ export const addNewCaseMap = async (selectionContext: AddCommandSelectionContext
           };
         })
       });
+      if (state.namespace === undefined || state.namespace === '') {
+        const projectDefaultNamespace = await resolveNamespaceFromPath(
+          Uri.file(state.project.path),
+          state.project.path,
+          resourceDirectoryTarget
+        );
+        if (validateNamespace(projectDefaultNamespace) === undefined) {
+          state.namespace = projectDefaultNamespace;
+        }
+      }
     }
   };
 

--- a/extension/src/project-explorer/new-case-map.ts
+++ b/extension/src/project-explorer/new-case-map.ts
@@ -34,6 +34,7 @@ export const addNewCaseMap = async (selectionContext: AddCommandSelectionContext
       state.project = state.projectFromSelection;
       state.projectFromSelection = undefined;
     } else {
+      const previousProject = state.project;
       state.project = await input.showQuickPick({
         title: state.dialogTitle,
         titleSuffix: ' - Choose project',
@@ -49,7 +50,7 @@ export const addNewCaseMap = async (selectionContext: AddCommandSelectionContext
           };
         })
       });
-      if (state.namespace === undefined || state.namespace === '') {
+      if (namespaceFromSelection === undefined && (previousProject === undefined || state.project.path !== previousProject.path)) {
         const projectDefaultNamespace = await resolveNamespaceFromPath(
           Uri.file(state.project.path),
           state.project.path,
@@ -98,7 +99,7 @@ export const addNewCaseMap = async (selectionContext: AddCommandSelectionContext
     dialogTitle: 'Add New Case Map',
     currentStep: 1,
     totalSteps: steps.length,
-    namespace: typeof namespaceFromSelection === 'string' && namespaceFromSelection.trim() !== '' ? namespaceFromSelection : '',
+    namespace: namespaceFromSelection,
     projectFromSelection: projectFromSelection
   };
 

--- a/extension/src/project-explorer/new-case-map.ts
+++ b/extension/src/project-explorer/new-case-map.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { Uri } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import { IvyEngineManager } from '../engine/engine-manager';
 import { type AddCommandSelectionContext } from './ivy-project-explorer';
@@ -9,10 +8,11 @@ import {
   MultiStepCancelledError,
   MultiStepInput,
   MultiStepInvalidStateError,
+  overrideProjectDefaultNamespaceIfAllowed,
   type ProjectSelection,
   resolveAddCommandSelectionContext
 } from './utils/multi-step-input';
-import { resolveNamespaceFromPath, type ResourceDirectoryTarget, validateNamespace, validateProjectArtifactName } from './utils/util';
+import { type ResourceDirectoryTarget, validateNamespace, validateProjectArtifactName } from './utils/util';
 
 interface NewCaseMapState extends MSStateBase {
   project?: ProjectSelection;
@@ -50,16 +50,7 @@ export const addNewCaseMap = async (selectionContext: AddCommandSelectionContext
           };
         })
       });
-      if (namespaceFromSelection === undefined && (previousProject === undefined || state.project.path !== previousProject.path)) {
-        const projectDefaultNamespace = await resolveNamespaceFromPath(
-          Uri.file(state.project.path),
-          state.project.path,
-          resourceDirectoryTarget
-        );
-        if (validateNamespace(projectDefaultNamespace) === undefined) {
-          state.namespace = projectDefaultNamespace;
-        }
-      }
+      await overrideProjectDefaultNamespaceIfAllowed(state, previousProject, resourceDirectoryTarget, validateNamespace);
     }
   };
 

--- a/extension/src/project-explorer/new-data-class.ts
+++ b/extension/src/project-explorer/new-data-class.ts
@@ -44,6 +44,7 @@ export const addNewDataClass = async (type: DataClassType, selectionContext: Add
       state.project = state.projectFromSelection;
       state.projectFromSelection = undefined;
     } else {
+      const previousProject = state.project;
       state.project = await input.showQuickPick<ProjectSelection>({
         title: state.dialogTitle,
         titleSuffix: ' - Choose project',
@@ -59,7 +60,7 @@ export const addNewDataClass = async (type: DataClassType, selectionContext: Add
           };
         })
       });
-      if (state.namespace === undefined || state.namespace === '') {
+      if (namespaceFromSelection === undefined && (previousProject === undefined || state.project.path !== previousProject.path)) {
         const projectDefaultNamespace = await resolveNamespaceFromPath(
           Uri.file(state.project.path),
           state.project.path,
@@ -108,7 +109,7 @@ export const addNewDataClass = async (type: DataClassType, selectionContext: Add
     dialogTitle: `Add New ${type}`,
     currentStep: 1,
     totalSteps: steps.length,
-    namespace: typeof namespaceFromSelection === 'string' && namespaceFromSelection.trim() !== '' ? namespaceFromSelection : undefined,
+    namespace: namespaceFromSelection,
     projectFromSelection: projectFromSelection
   };
 

--- a/extension/src/project-explorer/new-data-class.ts
+++ b/extension/src/project-explorer/new-data-class.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { Uri } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import { type DataClassInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
@@ -12,7 +13,12 @@ import {
   type MSStateBase,
   type ProjectSelection
 } from './utils/multi-step-input';
-import { validateDotSeparatedName, validateProjectArtifactName } from './utils/util';
+import {
+  resolveNamespaceFromPath,
+  validateDotSeparatedName,
+  validateProjectArtifactName,
+  type ResourceDirectoryTarget
+} from './utils/util';
 
 type DataClassType = 'Data Class' | 'Entity Class';
 
@@ -26,8 +32,12 @@ interface NewDataClassState extends MSStateBase {
 }
 
 export const addNewDataClass = async (type: DataClassType, selectionContext: AddCommandSelectionContext) => {
+  const resourceDirectoryTarget: ResourceDirectoryTarget = 'dataclasses';
   const existingProjects = selectionContext.existingIvyProjects;
-  const { projectFromSelection, namespaceFromSelection } = await resolveAddCommandSelectionContext(selectionContext, 'dataclasses');
+  const { projectFromSelection, namespaceFromSelection } = await resolveAddCommandSelectionContext(
+    selectionContext,
+    resourceDirectoryTarget
+  );
 
   const stepProject: InputStep<NewDataClassState> = async (input: MultiStepInput<NewDataClassState>, state: NewDataClassState) => {
     if (state.projectFromSelection && state.project === undefined) {
@@ -49,6 +59,16 @@ export const addNewDataClass = async (type: DataClassType, selectionContext: Add
           };
         })
       });
+      if (state.namespace === undefined || state.namespace === '') {
+        const projectDefaultNamespace = await resolveNamespaceFromPath(
+          Uri.file(state.project.path),
+          state.project.path,
+          resourceDirectoryTarget
+        );
+        if (validateDotSeparatedName(projectDefaultNamespace) === undefined) {
+          state.namespace = projectDefaultNamespace;
+        }
+      }
     }
   };
 

--- a/extension/src/project-explorer/new-data-class.ts
+++ b/extension/src/project-explorer/new-data-class.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { Uri } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import { type DataClassInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
@@ -8,17 +7,13 @@ import {
   MultiStepCancelledError,
   MultiStepInput,
   MultiStepInvalidStateError,
+  overrideProjectDefaultNamespaceIfAllowed,
   resolveAddCommandSelectionContext,
   type InputStep,
   type MSStateBase,
   type ProjectSelection
 } from './utils/multi-step-input';
-import {
-  resolveNamespaceFromPath,
-  validateDotSeparatedName,
-  validateProjectArtifactName,
-  type ResourceDirectoryTarget
-} from './utils/util';
+import { validateDotSeparatedName, validateProjectArtifactName, type ResourceDirectoryTarget } from './utils/util';
 
 type DataClassType = 'Data Class' | 'Entity Class';
 
@@ -60,16 +55,7 @@ export const addNewDataClass = async (type: DataClassType, selectionContext: Add
           };
         })
       });
-      if (namespaceFromSelection === undefined && (previousProject === undefined || state.project.path !== previousProject.path)) {
-        const projectDefaultNamespace = await resolveNamespaceFromPath(
-          Uri.file(state.project.path),
-          state.project.path,
-          resourceDirectoryTarget
-        );
-        if (validateDotSeparatedName(projectDefaultNamespace) === undefined) {
-          state.namespace = projectDefaultNamespace;
-        }
-      }
+      await overrideProjectDefaultNamespaceIfAllowed(state, previousProject, resourceDirectoryTarget, validateDotSeparatedName);
     }
   };
 

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { Uri } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import type { ProcessInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
@@ -8,12 +7,13 @@ import {
   MultiStepCancelledError,
   MultiStepInput,
   MultiStepInvalidStateError,
+  overrideProjectDefaultNamespaceIfAllowed,
   resolveAddCommandSelectionContext,
   type InputStep,
   type MSStateBase,
   type ProjectSelection
 } from './utils/multi-step-input';
-import { resolveNamespaceFromPath, validateNamespace, validateProjectArtifactName, type ResourceDirectoryTarget } from './utils/util';
+import { validateNamespace, validateProjectArtifactName, type ResourceDirectoryTarget } from './utils/util';
 
 export type ProcessKind = 'Business Process' | 'Callable Sub Process' | 'Web Service Process' | '';
 
@@ -55,16 +55,7 @@ export const addNewProcess = async (selectionContext: AddCommandSelectionContext
           };
         })
       });
-      if (namespaceFromSelection === undefined && (previousProject === undefined || state.project.path !== previousProject.path)) {
-        const projectDefaultNamespace = await resolveNamespaceFromPath(
-          Uri.file(state.project.path),
-          state.project.path,
-          resourceDirectoryTarget
-        );
-        if (validateNamespace(projectDefaultNamespace) === undefined) {
-          state.namespace = projectDefaultNamespace;
-        }
-      }
+      await overrideProjectDefaultNamespaceIfAllowed(state, previousProject, resourceDirectoryTarget, validateNamespace);
     }
   };
 

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { Uri } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import type { ProcessInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
@@ -12,7 +13,7 @@ import {
   type MSStateBase,
   type ProjectSelection
 } from './utils/multi-step-input';
-import { validateNamespace, validateProjectArtifactName } from './utils/util';
+import { resolveNamespaceFromPath, validateNamespace, validateProjectArtifactName, type ResourceDirectoryTarget } from './utils/util';
 
 export type ProcessKind = 'Business Process' | 'Callable Sub Process' | 'Web Service Process' | '';
 
@@ -26,8 +27,12 @@ interface NewProcessState extends MSStateBase {
 }
 
 export const addNewProcess = async (selectionContext: AddCommandSelectionContext, kind: ProcessKind = 'Business Process', pid?: string) => {
+  const resourceDirectoryTarget: ResourceDirectoryTarget = 'processes';
   const existingProjects = selectionContext.existingIvyProjects;
-  const { projectFromSelection, namespaceFromSelection } = await resolveAddCommandSelectionContext(selectionContext, 'processes');
+  const { projectFromSelection, namespaceFromSelection } = await resolveAddCommandSelectionContext(
+    selectionContext,
+    resourceDirectoryTarget
+  );
 
   const stepProject: InputStep<NewProcessState> = async (input: MultiStepInput<NewProcessState>, state: NewProcessState) => {
     if (state.projectFromSelection && state.project === undefined) {
@@ -49,6 +54,16 @@ export const addNewProcess = async (selectionContext: AddCommandSelectionContext
           };
         })
       });
+      if (state.namespace === undefined || state.namespace === '') {
+        const projectDefaultNamespace = await resolveNamespaceFromPath(
+          Uri.file(state.project.path),
+          state.project.path,
+          resourceDirectoryTarget
+        );
+        if (validateNamespace(projectDefaultNamespace) === undefined) {
+          state.namespace = projectDefaultNamespace;
+        }
+      }
     }
   };
 

--- a/extension/src/project-explorer/new-process.ts
+++ b/extension/src/project-explorer/new-process.ts
@@ -39,6 +39,7 @@ export const addNewProcess = async (selectionContext: AddCommandSelectionContext
       state.project = state.projectFromSelection;
       state.projectFromSelection = undefined;
     } else {
+      const previousProject = state.project;
       state.project = await input.showQuickPick({
         title: state.dialogTitle,
         titleSuffix: ' - Choose project',
@@ -54,7 +55,7 @@ export const addNewProcess = async (selectionContext: AddCommandSelectionContext
           };
         })
       });
-      if (state.namespace === undefined || state.namespace === '') {
+      if (namespaceFromSelection === undefined && (previousProject === undefined || state.project.path !== previousProject.path)) {
         const projectDefaultNamespace = await resolveNamespaceFromPath(
           Uri.file(state.project.path),
           state.project.path,
@@ -104,7 +105,7 @@ export const addNewProcess = async (selectionContext: AddCommandSelectionContext
     dialogTitle: `Add New ${kind}`,
     currentStep: 1,
     totalSteps: steps.length,
-    namespace: typeof namespaceFromSelection === 'string' && namespaceFromSelection.trim() !== '' ? namespaceFromSelection : '',
+    namespace: namespaceFromSelection,
     projectFromSelection: projectFromSelection
   };
 

--- a/extension/src/project-explorer/new-user-dialog.ts
+++ b/extension/src/project-explorer/new-user-dialog.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { Uri, type QuickPickItem } from 'vscode';
+import { type QuickPickItem } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import type { HdInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
@@ -8,17 +8,13 @@ import {
   MultiStepCancelledError,
   MultiStepInput,
   MultiStepInvalidStateError,
+  overrideProjectDefaultNamespaceIfAllowed,
   resolveAddCommandSelectionContext,
   type InputStep,
   type MSStateBase,
   type ProjectSelection
 } from './utils/multi-step-input';
-import {
-  resolveNamespaceFromPath,
-  validateDotSeparatedName,
-  validateProjectArtifactName,
-  type ResourceDirectoryTarget
-} from './utils/util';
+import { validateDotSeparatedName, validateProjectArtifactName, type ResourceDirectoryTarget } from './utils/util';
 
 export const dialogTypes = ['JSF', 'Form', 'JSFOffline'] as const;
 export type DialogType = (typeof dialogTypes)[number];
@@ -135,16 +131,7 @@ export const addNewUserDialog = async (selectionContext: AddCommandSelectionCont
           };
         })
       });
-      if (namespaceFromSelection === undefined && (previousProject === undefined || state.project.path !== previousProject.path)) {
-        const projectDefaultNamespace = await resolveNamespaceFromPath(
-          Uri.file(state.project.path),
-          state.project.path,
-          resourceDirectoryTarget
-        );
-        if (validateDotSeparatedName(projectDefaultNamespace) === undefined) {
-          state.namespace = projectDefaultNamespace;
-        }
-      }
+      await overrideProjectDefaultNamespaceIfAllowed(state, previousProject, resourceDirectoryTarget, validateDotSeparatedName);
     }
   };
 

--- a/extension/src/project-explorer/new-user-dialog.ts
+++ b/extension/src/project-explorer/new-user-dialog.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { type QuickPickItem } from 'vscode';
+import { Uri, type QuickPickItem } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import type { HdInit } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
@@ -13,7 +13,12 @@ import {
   type MSStateBase,
   type ProjectSelection
 } from './utils/multi-step-input';
-import { validateDotSeparatedName, validateProjectArtifactName } from './utils/util';
+import {
+  resolveNamespaceFromPath,
+  validateDotSeparatedName,
+  validateProjectArtifactName,
+  type ResourceDirectoryTarget
+} from './utils/util';
 
 export const dialogTypes = ['JSF', 'Form', 'JSFOffline'] as const;
 export type DialogType = (typeof dialogTypes)[number];
@@ -102,8 +107,12 @@ const prepareAndValidateFinalState: (
 };
 
 export const addNewUserDialog = async (selectionContext: AddCommandSelectionContext, type: DialogType, pid?: string) => {
+  const resourceDirectoryTarget: ResourceDirectoryTarget = 'src_hd';
   const existingProjects = selectionContext.existingIvyProjects;
-  const { projectFromSelection, namespaceFromSelection } = await resolveAddCommandSelectionContext(selectionContext, 'src_hd');
+  const { projectFromSelection, namespaceFromSelection } = await resolveAddCommandSelectionContext(
+    selectionContext,
+    resourceDirectoryTarget
+  );
 
   const stepProject: InputStep<NewUserDialogState> = async (input: MultiStepInput<NewUserDialogState>, state: NewUserDialogState) => {
     if (state.projectFromSelection && state.project === undefined) {
@@ -125,6 +134,16 @@ export const addNewUserDialog = async (selectionContext: AddCommandSelectionCont
           };
         })
       });
+      if (state.namespace === undefined || state.namespace === '') {
+        const projectDefaultNamespace = await resolveNamespaceFromPath(
+          Uri.file(state.project.path),
+          state.project.path,
+          resourceDirectoryTarget
+        );
+        if (validateDotSeparatedName(projectDefaultNamespace) === undefined) {
+          state.namespace = projectDefaultNamespace;
+        }
+      }
     }
   };
 

--- a/extension/src/project-explorer/new-user-dialog.ts
+++ b/extension/src/project-explorer/new-user-dialog.ts
@@ -119,6 +119,7 @@ export const addNewUserDialog = async (selectionContext: AddCommandSelectionCont
       state.project = state.projectFromSelection;
       state.projectFromSelection = undefined;
     } else {
+      const previousProject = state.project;
       state.project = await input.showQuickPick<ProjectSelection>({
         title: state.dialogTitle,
         titleSuffix: ' - Choose project',
@@ -134,7 +135,7 @@ export const addNewUserDialog = async (selectionContext: AddCommandSelectionCont
           };
         })
       });
-      if (state.namespace === undefined || state.namespace === '') {
+      if (namespaceFromSelection === undefined && (previousProject === undefined || state.project.path !== previousProject.path)) {
         const projectDefaultNamespace = await resolveNamespaceFromPath(
           Uri.file(state.project.path),
           state.project.path,
@@ -232,7 +233,7 @@ export const addNewUserDialog = async (selectionContext: AddCommandSelectionCont
     dialogTitle: `Add New ${type}`,
     currentStep: 1,
     totalSteps: steps.length,
-    namespace: typeof namespaceFromSelection === 'string' && namespaceFromSelection.trim() !== '' ? namespaceFromSelection : undefined,
+    namespace: namespaceFromSelection,
     projectFromSelection: projectFromSelection
   };
 

--- a/extension/src/project-explorer/utils/multi-step-input.ts
+++ b/extension/src/project-explorer/utils/multi-step-input.ts
@@ -145,6 +145,7 @@ export class MultiStepInput<T extends MSStateBase> {
       input.placeholder = placeholder ?? '';
       input.ignoreFocusOut = ignoreFocusOut ?? true;
       input.buttons = currentStep > 1 ? [QuickInputButtons.Back] : [];
+      input.validationMessage = validationFunction ? validationFunction(input.value) : '';
       disposables.push(
         input.onDidTriggerButton(item => {
           if (item === QuickInputButtons.Back) {

--- a/extension/src/project-explorer/utils/multi-step-input.ts
+++ b/extension/src/project-explorer/utils/multi-step-input.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import type { QuickInput, QuickPickItem } from 'vscode';
-import { Disposable, QuickInputButtons, window } from 'vscode';
+import { Disposable, QuickInputButtons, Uri, window } from 'vscode';
 import { type AddCommandSelectionContext } from '../ivy-project-explorer';
 import { resolveNamespaceFromPath, type ResourceDirectoryTarget } from './util';
 
@@ -56,6 +56,37 @@ export const resolveAddCommandSelectionContext = async (
   }
   const namespaceFromSelection = await resolveNamespaceFromPath(uriFromSelection, projectPathFromSelection, resourceDirectoryTarget);
   return { projectFromSelection, namespaceFromSelection };
+};
+
+type StateWithProjectAndNamespace = MSStateBase & {
+  project: ProjectSelection;
+  namespace: string;
+};
+
+function stateHasProjectAndNamespace(state: MSStateBase): state is StateWithProjectAndNamespace {
+  return 'project' in state && 'namespace' in state;
+}
+
+export const overrideProjectDefaultNamespaceIfAllowed = async <S extends MSStateBase>(
+  state: S,
+  previousProject: ProjectSelection | undefined,
+  resourceDirectoryTarget: ResourceDirectoryTarget,
+  validationFunction: (namespace: string) => string | undefined
+): Promise<void> => {
+  if (!stateHasProjectAndNamespace(state)) {
+    return;
+  }
+  if (previousProject === undefined || state.project.path !== previousProject.path) {
+    const projectDefaultNamespace = await resolveNamespaceFromPath(
+      Uri.file(state.project.path),
+      state.project.path,
+      resourceDirectoryTarget
+    );
+    if (validationFunction(projectDefaultNamespace) === undefined) {
+      state.namespace = projectDefaultNamespace;
+    }
+  }
+  return;
 };
 
 export type InputStep<T extends MSStateBase> = (input: MultiStepInput<T>, state: T) => Thenable<InputStep<T>> | Promise<void>;

--- a/playwright/tests/page-objects/explorer-view.ts
+++ b/playwright/tests/page-objects/explorer-view.ts
@@ -100,11 +100,17 @@ export class FileExplorer extends ExplorerView {
     await this.provideUserInput();
   }
 
-  async addProcess(processName: string, kind: 'Business Process' | 'Callable Sub Process' | 'Web Service Process', namespace?: string) {
+  async addProcess(
+    processName: string,
+    kind: 'Business Process' | 'Callable Sub Process' | 'Web Service Process',
+    defaultNamespaceExpected: string = 'prebuiltProject',
+    namespace?: string
+  ) {
     await this.selectNode('config');
     await this.executeCommand('Axon Ivy: New ' + kind);
     await this.selectNthVisibleItemFromQuickPick(0);
     await this.provideUserInput(processName);
+    expect(await this.readInputBoxValue()).toBe(defaultNamespaceExpected);
     await this.provideUserInput(namespace);
   }
 
@@ -123,11 +129,17 @@ export class FileExplorer extends ExplorerView {
     await this.provideUserInput(productId);
   }
 
-  async addUserDialog(dialogName: string, namespace: string, kind: 'Html Dialog (JSF)' | 'Offline Dialog (JSF)' | 'Dialog Form') {
+  async addUserDialog(
+    dialogName: string,
+    namespace: string,
+    kind: 'Html Dialog (JSF)' | 'Offline Dialog (JSF)' | 'Dialog Form',
+    defaultNamespaceExpected: string = 'prebuiltProject'
+  ) {
     await this.selectNode('config');
     await this.executeCommand('Axon Ivy: New ' + kind);
     await this.selectNthVisibleItemFromQuickPick(0);
     await this.provideUserInput(dialogName);
+    expect(await this.readInputBoxValue()).toBe(defaultNamespaceExpected);
     await this.provideUserInput(namespace);
     if (kind === 'Html Dialog (JSF)') {
       await this.provideUserInput();
@@ -135,19 +147,21 @@ export class FileExplorer extends ExplorerView {
     }
   }
 
-  async addDataClass(dataClass: string, namespace: string) {
+  async addDataClass(dataClass: string, namespace: string, defaultNamespaceExpected: string = 'prebuiltProject') {
     await this.selectNode('config');
     await this.executeCommand('Axon Ivy: New Data Class');
     await this.selectNthVisibleItemFromQuickPick(0);
     await this.provideUserInput(dataClass);
+    expect(await this.readInputBoxValue()).toBe(defaultNamespaceExpected);
     await this.provideUserInput(namespace);
   }
 
-  async addEntityClass(entityClass: string, namespace: string) {
+  async addEntityClass(entityClass: string, namespace: string, defaultNamespaceExpected: string = 'prebuiltProject') {
     await this.selectNode('config');
     await this.executeCommand('Axon Ivy: New Entity Class');
     await this.selectNthVisibleItemFromQuickPick(0);
     await this.provideUserInput(entityClass);
+    expect(await this.readInputBoxValue()).toBe(defaultNamespaceExpected);
     await this.provideUserInput(namespace);
   }
 }

--- a/playwright/tests/page-objects/explorer-view.ts
+++ b/playwright/tests/page-objects/explorer-view.ts
@@ -113,7 +113,7 @@ export class FileExplorer extends ExplorerView {
     await this.executeCommand('Axon Ivy: New ' + kind);
     await this.selectNthVisibleItemFromQuickPick(0);
     await this.provideUserInput(processName);
-    expect(await this.readInputBoxValue()).toBe(defaultNamespaceExpected);
+    await expect(this.quickInputBox().getByRole('textbox')).toHaveValue(defaultNamespaceExpected);
     await this.provideUserInput(namespace);
   }
 
@@ -142,7 +142,7 @@ export class FileExplorer extends ExplorerView {
     await this.executeCommand('Axon Ivy: New ' + kind);
     await this.selectNthVisibleItemFromQuickPick(0);
     await this.provideUserInput(dialogName);
-    expect(await this.readInputBoxValue()).toBe(defaultNamespaceExpected);
+    await expect(this.quickInputBox().getByRole('textbox')).toHaveValue(defaultNamespaceExpected);
     await this.provideUserInput(namespace);
     if (kind === 'Html Dialog (JSF)') {
       await this.provideUserInput();
@@ -155,7 +155,7 @@ export class FileExplorer extends ExplorerView {
     await this.executeCommand('Axon Ivy: New Data Class');
     await this.selectNthVisibleItemFromQuickPick(0);
     await this.provideUserInput(dataClass);
-    expect(await this.readInputBoxValue()).toBe(defaultNamespaceExpected);
+    await expect(this.quickInputBox().getByRole('textbox')).toHaveValue(defaultNamespaceExpected);
     await this.provideUserInput(namespace);
   }
 
@@ -164,7 +164,7 @@ export class FileExplorer extends ExplorerView {
     await this.executeCommand('Axon Ivy: New Entity Class');
     await this.selectNthVisibleItemFromQuickPick(0);
     await this.provideUserInput(entityClass);
-    expect(await this.readInputBoxValue()).toBe(defaultNamespaceExpected);
+    await expect(this.quickInputBox().getByRole('textbox')).toHaveValue(defaultNamespaceExpected);
     await this.provideUserInput(namespace);
   }
 }

--- a/playwright/tests/page-objects/explorer-view.ts
+++ b/playwright/tests/page-objects/explorer-view.ts
@@ -103,9 +103,12 @@ export class FileExplorer extends ExplorerView {
   async addProcess(
     processName: string,
     kind: 'Business Process' | 'Callable Sub Process' | 'Web Service Process',
-    defaultNamespaceExpected: string = 'prebuiltProject',
-    namespace?: string
+    namespace?: string,
+    defaultNamespaceExpected?: string
   ) {
+    if (defaultNamespaceExpected === undefined) {
+      defaultNamespaceExpected = 'prebuiltProject';
+    }
     await this.selectNode('config');
     await this.executeCommand('Axon Ivy: New ' + kind);
     await this.selectNthVisibleItemFromQuickPick(0);

--- a/playwright/tests/page-objects/page-object.ts
+++ b/playwright/tests/page-objects/page-object.ts
@@ -102,4 +102,8 @@ export class PageObject {
     await item.click();
     await expect(item).toBeHidden();
   }
+
+  async readInputBoxValue() {
+    return await this.page.locator('.quick-input-box').locator('.input').inputValue();
+  }
 }

--- a/playwright/tests/page-objects/page-object.ts
+++ b/playwright/tests/page-objects/page-object.ts
@@ -102,8 +102,4 @@ export class PageObject {
     await item.click();
     await expect(item).toBeHidden();
   }
-
-  async readInputBoxValue() {
-    return await this.page.locator('.quick-input-box').locator('.input').inputValue();
-  }
 }


### PR DESCRIPTION
Set the `namespace` input default to the namespace of the selected project, if the user did not select a project via tree selection (right click)
- Implemented for all commands that have a project selection and a namespace input
  - New Business / Callable / Webservice Process
  - New Data Class / Entity Class
  - New Html / Form / Offliine Dialog
  - New Case Map
- Initially only takes effect if the user has not selected a valid filepath via rightclick in File Explorer or Axon Ivy Projects tree. If this selection exists, it is respected over the default project namespace.
- Updates the proposed `namespace` whenever the project selection in the earlier step changes.
- As long as the project selection does not change, the user entered namespace will be conserved.