### PR TITLE
XIVY-18808 setting for xhtml workspace validation suppression

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -504,6 +504,11 @@
               "noEmbeddedProcesses"
             ],
             "markdownDescription": "Specify process animation mode."
+          },
+          "axonivy.validation.xhtml": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Configure whether the Xhtml WorkspaceValidation is enabled."
           }
         }
       }


### PR DESCRIPTION
adds setting to suppress xhtml workspace validation
<img width="439" height="80" alt="image" src="https://github.com/user-attachments/assets/1513af1d-0f79-4c34-b5f0-cf054e1895b2" />
