### PR TITLE
XIVY-18535 use: 'ws' prefix for soap-codegen output

### DIFF
--- a/extension/src/editors/webservice-editor/webview-communication.ts
+++ b/extension/src/editors/webservice-editor/webview-communication.ts
@@ -90,7 +90,7 @@ async function generateClient(codegen: WsGeneratorConfig, document: TextDocument
   const projectPath = path.dirname(path.dirname(document.uri.fsPath));
 
   try {
-    const outputDir = `src_generated/soap/${codegen.clientName}`;
+    const outputDir = `src_generated/ws/${codegen.clientName}`;
 
     const commandParts = [
       'mvn com.axonivy.ivy.tool.soap:cxf-client-codegen:generate-cxf-client -ntp',


### PR DESCRIPTION
seems like the prefix we already use in our demo-projects is 'ws' ... not 'soap'

https://github.com/axonivy/demo-projects/blob/08bcd11d5d6d4e52b0c6dcdda313c6f8ac86c7c9/connectivity/connectivity-demos/pom.xml#L126