### PR TITLE
XIVY-18535 pick URI: windows compatible 

### DIFF
--- a/extension/src/editors/file-picker.ts
+++ b/extension/src/editors/file-picker.ts
@@ -31,5 +31,5 @@ export async function pickFile(request: FilePickRequestLike, document: TextDocum
     return relativePath;
   }
 
-  return selected.fsPath;
+  return selected.toString();
 }


### PR DESCRIPTION
Bruno found this; we can't deal properly with windows file paths ... so we rather create an URI.

works:
<img width="1596" height="1064" alt="vsc-codegen-win" src="https://github.com/user-attachments/assets/ac18f504-92c7-4cfc-81a7-1bab701048d4" />

did not work:
<img width="1877" height="997" alt="not-work-ws" src="https://github.com/user-attachments/assets/96e9bded-7a79-4159-9c9f-3fe23f39f63c" />

