### PR TITLE
XIVY-19324 make extension deactivation work

### DIFF
--- a/extension/src/engine/engine-manager.ts
+++ b/extension/src/engine/engine-manager.ts
@@ -234,9 +234,6 @@ export class IvyEngineManager {
   }
 
   public async createProject(newProjectParams: NewProjectParams & { path: string }) {
-    if (!this.started) {
-      await this.start();
-    }
     return await StatusBar.withStatusBarProgress({ text: 'Creating and deploying new project' }, async () => {
       const projectBean = await this.ivyEngineApi?.createProject(newProjectParams);
       await IvyProjectExplorer.instance.setProjectExplorerContext({ hasIvyProjects: true });

--- a/extension/src/engine/engine-manager.ts
+++ b/extension/src/engine/engine-manager.ts
@@ -117,8 +117,8 @@ export class IvyEngineManager {
       return;
     }
     this.started = true;
-    await IvyProjectExplorer.instance.setProjectExplorerContext({ isStarted: true });
     this.resolvedEngineUrl = await this.resolveEngineUrl();
+    await executeCommand('setContext', 'ivy:isStarted', 'true');
     this.ivyEngineApi = await IvyEngineApi.init(this.resolvedEngineUrl.toString());
     let devContextPath = this.ivyEngineApi.devContextPath;
     IvyBrowserViewProvider.register(this.context, this.resolvedEngineUrl, devContextPath);
@@ -236,7 +236,7 @@ export class IvyEngineManager {
   public async createProject(newProjectParams: NewProjectParams & { path: string }) {
     return await StatusBar.withStatusBarProgress({ text: 'Creating and deploying new project' }, async () => {
       const projectBean = await this.ivyEngineApi?.createProject(newProjectParams);
-      await IvyProjectExplorer.instance.setProjectExplorerContext({ hasIvyProjects: true });
+      // await IvyProjectExplorer.instance.setProjectExplorerContext({ hasIvyProjects: true });
       await this.importJavaProjects();
       await this.createAndOpenProcess({
         name: 'BusinessProcess',

--- a/extension/src/engine/engine-manager.ts
+++ b/extension/src/engine/engine-manager.ts
@@ -236,7 +236,6 @@ export class IvyEngineManager {
   public async createProject(newProjectParams: NewProjectParams & { path: string }) {
     return await StatusBar.withStatusBarProgress({ text: 'Creating and deploying new project' }, async () => {
       const projectBean = await this.ivyEngineApi?.createProject(newProjectParams);
-      // await IvyProjectExplorer.instance.setProjectExplorerContext({ hasIvyProjects: true });
       await this.importJavaProjects();
       await this.createAndOpenProcess({
         name: 'BusinessProcess',

--- a/extension/src/index.ts
+++ b/extension/src/index.ts
@@ -56,7 +56,7 @@ export async function activate(context: ExtensionContext): Promise<MessengerDiag
     IvyDiagnostics.init(context);
     conditionalWelcomePage(context);
 
-    await IvyProjectExplorer.init(context);
+    IvyProjectExplorer.init(context);
     registerAddDependencyHandler(context);
     StatusBar.refreshStatusBar();
     return messenger.diagnosticApi();

--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -26,10 +26,10 @@ export class IvyProjectExplorer {
   private static _instance: IvyProjectExplorer;
   private readonly treeDataProvider: IvyProjectTreeDataProvider;
   private readonly treeView: TreeView<Entry>;
-  private initPromise: Promise<void> | undefined;
 
   private constructor(context: ExtensionContext) {
-    this.treeDataProvider = new IvyProjectTreeDataProvider(this.initPromise);
+    const activateEnginePromise = this.activateEngineIfNeeded();
+    this.treeDataProvider = new IvyProjectTreeDataProvider(activateEnginePromise);
     this.treeView = window.createTreeView(VIEW_ID, { treeDataProvider: this.treeDataProvider, showCollapseAll: true });
     context.subscriptions.push(this.treeView);
     this.treeView.onDidChangeVisibility((event: TreeViewVisibilityChangeEvent) => {
@@ -40,6 +40,13 @@ export class IvyProjectExplorer {
         }
       }
     });
+    this.registerCommands(context);
+    this.defineFileWatchers(context);
+    context.subscriptions.push(
+      workspace.onDidChangeWorkspaceFolders(async () => {
+        await this.refresh();
+      })
+    );
   }
 
   static async init(context: ExtensionContext) {
@@ -47,12 +54,6 @@ export class IvyProjectExplorer {
       throw new Error('IvyProjectExplorer has already been initialized');
     }
     IvyProjectExplorer._instance = new IvyProjectExplorer(context);
-    IvyProjectExplorer._instance.initPromise = IvyProjectExplorer._instance.activateEngineIfNeeded();
-    IvyProjectExplorer._instance.registerCommands(context);
-    IvyProjectExplorer._instance.defineFileWatchers(context);
-    workspace.onDidChangeWorkspaceFolders(async () => {
-      await IvyProjectExplorer._instance.refresh();
-    });
   }
 
   private async activateEngineIfNeeded() {

--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -26,9 +26,10 @@ export class IvyProjectExplorer {
   private static _instance: IvyProjectExplorer;
   private readonly treeDataProvider: IvyProjectTreeDataProvider;
   private readonly treeView: TreeView<Entry>;
+  private initPromise: Promise<void> | undefined;
 
   private constructor(context: ExtensionContext) {
-    this.treeDataProvider = new IvyProjectTreeDataProvider();
+    this.treeDataProvider = new IvyProjectTreeDataProvider(this.initPromise);
     this.treeView = window.createTreeView(VIEW_ID, { treeDataProvider: this.treeDataProvider, showCollapseAll: true });
     context.subscriptions.push(this.treeView);
     this.treeView.onDidChangeVisibility((event: TreeViewVisibilityChangeEvent) => {
@@ -43,10 +44,10 @@ export class IvyProjectExplorer {
 
   static async init(context: ExtensionContext) {
     if (IvyProjectExplorer._instance) {
-      return IvyProjectExplorer._instance;
+      throw new Error('IvyProjectExplorer has already been initialized');
     }
     IvyProjectExplorer._instance = new IvyProjectExplorer(context);
-    await IvyProjectExplorer._instance.activateEngineIfNeeded();
+    IvyProjectExplorer._instance.initPromise = IvyProjectExplorer._instance.activateEngineIfNeeded();
     IvyProjectExplorer._instance.registerCommands(context);
     IvyProjectExplorer._instance.defineFileWatchers(context);
     workspace.onDidChangeWorkspaceFolders(async () => {
@@ -55,8 +56,6 @@ export class IvyProjectExplorer {
   }
 
   private async activateEngineIfNeeded() {
-    const hasIvyProjects = await this.hasIvyProjects();
-    await this.setProjectExplorerContext({ hasIvyProjects: hasIvyProjects });
     const workspaceHasOpenFolders = workspace.workspaceFolders && workspace.workspaceFolders.length > 0;
     if (!workspaceHasOpenFolders) {
       return;

--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -295,15 +295,6 @@ export class IvyProjectExplorer {
     await addNewDataClass('Entity Class', addCommandContext);
   }
 
-  public async setProjectExplorerContext({ hasIvyProjects, isStarted }: { hasIvyProjects?: boolean; isStarted?: boolean }) {
-    if (hasIvyProjects !== undefined) {
-      await executeCommand('setContext', 'ivy:hasIvyProjects', hasIvyProjects);
-    }
-    if (isStarted !== undefined) {
-      await executeCommand('setContext', 'ivy:isStarted', isStarted);
-    }
-  }
-
   public async selectCmsEntry(projectPath: string) {
     if (!this.treeView.visible) {
       return;

--- a/extension/src/project-explorer/ivy-project-tree-data-provider.ts
+++ b/extension/src/project-explorer/ivy-project-tree-data-provider.ts
@@ -99,6 +99,7 @@ export class IvyProjectTreeDataProvider implements TreeDataProvider<Entry> {
         });
       }
     });
+    await IvyProjectExplorer.instance.setProjectExplorerContext({ hasIvyProjects: validProjects.length > 0 });
     return { projects: validProjects.sort(), diagnostics };
   }
 

--- a/extension/src/project-explorer/ivy-project-tree-data-provider.ts
+++ b/extension/src/project-explorer/ivy-project-tree-data-provider.ts
@@ -14,7 +14,7 @@ import {
   type TreeDataProvider,
   type Command as VSCodeCommand
 } from 'vscode';
-import type { Command } from '../base/commands';
+import { executeCommand, type Command } from '../base/commands';
 import { config } from '../base/configurations';
 import { CmsEditorRegistry } from '../editors/cms-editor/cms-editor-registry';
 import { IvyProjectExplorer } from './ivy-project-explorer';
@@ -99,7 +99,7 @@ export class IvyProjectTreeDataProvider implements TreeDataProvider<Entry> {
         });
       }
     });
-    await IvyProjectExplorer.instance.setProjectExplorerContext({ hasIvyProjects: validProjects.length > 0 });
+    await executeCommand('setContext', 'ivy:hasIvyProjects', validProjects.length > 0);
     return { projects: validProjects.sort(), diagnostics };
   }
 

--- a/extension/src/project-explorer/ivy-project-tree-data-provider.ts
+++ b/extension/src/project-explorer/ivy-project-tree-data-provider.ts
@@ -65,7 +65,7 @@ export class IvyProjectTreeDataProvider implements TreeDataProvider<Entry> {
   private readonly excludePattern: string;
   private readonly maxResults: number;
 
-  constructor(readonly initPromise: Promise<void> | undefined) {
+  constructor(readonly activateEnginePromise: Promise<void>) {
     this.excludePattern = config.projectExcludePattern() ?? '';
     this.maxResults = config.projectMaximumNumber() ?? 50;
     this.ivyProjects = this.findIvyProjects();
@@ -153,7 +153,7 @@ export class IvyProjectTreeDataProvider implements TreeDataProvider<Entry> {
   }
 
   async getChildren(element?: Entry): Promise<Entry[]> {
-    await this.initPromise;
+    await this.activateEnginePromise;
     if (element) {
       return [this.cmsEntry(element)];
     }

--- a/extension/src/project-explorer/ivy-project-tree-data-provider.ts
+++ b/extension/src/project-explorer/ivy-project-tree-data-provider.ts
@@ -65,7 +65,7 @@ export class IvyProjectTreeDataProvider implements TreeDataProvider<Entry> {
   private readonly excludePattern: string;
   private readonly maxResults: number;
 
-  constructor() {
+  constructor(readonly initPromise: Promise<void> | undefined) {
     this.excludePattern = config.projectExcludePattern() ?? '';
     this.maxResults = config.projectMaximumNumber() ?? 50;
     this.ivyProjects = this.findIvyProjects();
@@ -152,6 +152,7 @@ export class IvyProjectTreeDataProvider implements TreeDataProvider<Entry> {
   }
 
   async getChildren(element?: Entry): Promise<Entry[]> {
+    await this.initPromise;
     if (element) {
       return [this.cmsEntry(element)];
     }


### PR DESCRIPTION
### Problem
Extension activation can be slow because it waits for the following call to complete:

```ts
await IvyProjectExplorer.init(context);
```

If VS Code is closed or reloaded before activation finishes, the extension never reaches the activated state. As a result, `deactivate()` is not called, preventing the engine from shutting down.

### Solution

Keep extension activation lightweight by removing the blocking `await` from `activate()`. Instead, defer the required initialization until the project explorer is actually used, where the initialization can be awaited as needed.