### PR TITLE
Import BPMN process -Allow XML filetype

### DIFF
--- a/extension/src/project-explorer/import-process.ts
+++ b/extension/src/project-explorer/import-process.ts
@@ -13,10 +13,10 @@ export const importNewProcess = async (projectDir: string) => {
 const collectImportBpmnProcessParams = async (projectDir: string): Promise<ImportProcessBody | undefined> => {
   const bpmnXmlFile = await window.showOpenDialog({
     canSelectMany: false,
-    title: 'Select BPMN .bpmn file to import',
+    title: 'Select BPMN .bpmn or .xml file to import',
     openLabel: 'Import BPMN Process',
     filters: {
-      'BPMN Files': ['bpmn']
+      'BPMN Files': ['bpmn', 'xml']
     }
   });
   if (!bpmnXmlFile || bpmnXmlFile.length === 0 || !bpmnXmlFile[0]) {


### PR DESCRIPTION
- Add XML filetype along with BPMN filetype as allowed for import process target
- Related to [this conversation](https://github.com/axonivy/vscode-designer/pull/1273/changes#diff-a1cfb933d21a6636b74d0b5529c7a19a800a7d79dd638ced798906784280978bR20)