### PR TITLE
Improve naming of XHTML workspace validation flag

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -551,7 +551,7 @@
           "axonivy.validation.xhtml": {
             "type": "boolean",
             "default": true,
-            "markdownDescription": "Configure whether the Xhtml WorkspaceValidation is enabled."
+            "markdownDescription": "Enable workspace-wide validation of XHTML files. When enabled, all XHTML files in the workspace are validated, not only files that are currently open."
           }
         }
       }


### PR DESCRIPTION
- The previous text was a bit confusing, as it wasn't immediately clear whether checking the option enabled or disabled validation. See:
<img width="898" height="136" alt="grafik" src="https://github.com/user-attachments/assets/10e858d4-37f2-44b8-94b6-d338d84744e1" />

The new text should make it clearer.