### PR TITLE
XIVY-19233 improve debounce

### DIFF
--- a/extension/src/base/debounce.test.ts
+++ b/extension/src/base/debounce.test.ts
@@ -1,0 +1,54 @@
+import { expect, test, vi } from 'vitest';
+import { debouncedAction, hasDeployActionInQueue } from './debounce';
+
+test.beforeAll(() => {
+  vi.useFakeTimers();
+});
+
+test.afterAll(() => {
+  vi.useRealTimers();
+});
+
+test('debounce deploy', async () => {
+  const values: string[] = [];
+  debouncedAction(
+    () => {
+      values.push('Deploy executed');
+    },
+    'deploy',
+    'test'
+  )();
+  debouncedAction(
+    () => {
+      values.push('Other executed');
+    },
+    'deploy',
+    'test'
+  )();
+  expect(values).toEqual([]);
+  expect(hasDeployActionInQueue()).toBe(true);
+  await vi.advanceTimersByTimeAsync(1_000);
+  expect(values).toContain('Deploy executed');
+});
+
+test('debounce invalidate', async () => {
+  const values: string[] = [];
+  debouncedAction(
+    () => {
+      values.push('Invalidate executed');
+    },
+    'invalidate',
+    'test'
+  )();
+  debouncedAction(
+    () => {
+      values.push('Other executed');
+    },
+    'invalidate',
+    'test'
+  )();
+  expect(values).toEqual([]);
+  expect(hasDeployActionInQueue()).toBe(false);
+  await vi.advanceTimersByTimeAsync(1_000);
+  expect(values).toContain('Invalidate executed');
+});

--- a/extension/src/base/debounce.test.ts
+++ b/extension/src/base/debounce.test.ts
@@ -35,9 +35,7 @@ test('debounce deploy', async () => {
   expect(values).toEqual([]);
   expect(hasDeployActionInQueue()).toBe(true);
   await vi.advanceTimersByTimeAsync(1_000);
-  expect(values.length).toBe(2);
-  expect(values).toContain('project1 deploy executed');
-  expect(values).toContain('project2 deploy executed');
+  expect(values).toEqual(['project1 deploy executed', 'project2 deploy executed']);
 });
 
 test('debounce invalidate', async () => {
@@ -59,5 +57,23 @@ test('debounce invalidate', async () => {
   expect(values).toEqual([]);
   expect(hasDeployActionInQueue()).toBe(false);
   await vi.advanceTimersByTimeAsync(1_000);
-  expect(values).toContain('Invalidate executed');
+  expect(values).toEqual(['Invalidate executed']);
+});
+
+test('debounce resets', async () => {
+  const values: string[] = [];
+  debouncedAction(() => {
+    values.push('push1');
+  }, 'deploy')();
+  debouncedAction(() => {
+    values.push('push2');
+  }, 'deploy')();
+  await vi.advanceTimersByTimeAsync(800);
+  debouncedAction(() => {
+    values.push('push3');
+  }, 'deploy')();
+  await vi.advanceTimersByTimeAsync(800);
+  expect(values).toEqual([]);
+  await vi.advanceTimersByTimeAsync(10_000);
+  expect(values).toEqual(['push1']);
 });

--- a/extension/src/base/debounce.test.ts
+++ b/extension/src/base/debounce.test.ts
@@ -13,22 +13,31 @@ test('debounce deploy', async () => {
   const values: string[] = [];
   debouncedAction(
     () => {
-      values.push('Deploy executed');
+      values.push('project1 deploy executed');
     },
     'deploy',
-    'test'
+    'project1'
   )();
   debouncedAction(
     () => {
       values.push('Other executed');
     },
     'deploy',
-    'test'
+    'project1'
+  )();
+  debouncedAction(
+    () => {
+      values.push('project2 deploy executed');
+    },
+    'deploy',
+    'project2'
   )();
   expect(values).toEqual([]);
   expect(hasDeployActionInQueue()).toBe(true);
   await vi.advanceTimersByTimeAsync(1_000);
-  expect(values).toContain('Deploy executed');
+  expect(values.length).toBe(2);
+  expect(values).toContain('project1 deploy executed');
+  expect(values).toContain('project2 deploy executed');
 });
 
 test('debounce invalidate', async () => {

--- a/extension/src/base/debounce.ts
+++ b/extension/src/base/debounce.ts
@@ -1,6 +1,10 @@
 const timers = new Map<string, NodeJS.Timeout>();
-export const debouncedAction = (action: () => void, key: string, timeout: number) => {
+
+export type ActionKey = 'deploy' | 'invalidate';
+
+export const debouncedAction = (action: () => void, actionKey: ActionKey, keyPrefix?: string) => {
   return () => {
+    const key = `${keyPrefix}:${actionKey}`;
     let timer = timers.get(key);
     if (timer) {
       timer.refresh();
@@ -12,7 +16,11 @@ export const debouncedAction = (action: () => void, key: string, timeout: number
       } finally {
         timers.delete(key);
       }
-    }, timeout);
+    }, 1_000);
     timers.set(key, timer);
   };
+};
+
+export const hasDeployActionInQueue = () => {
+  return Array.from(timers.keys()).some(key => key.endsWith(':deploy'));
 };

--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import type { ExtensionContext, TreeView, TreeViewVisibilityChangeEvent } from 'vscode';
 import { Uri, window, workspace } from 'vscode';
 import { executeCommand, registerCommand, type Command } from '../base/commands';
-import { debouncedAction } from '../base/debounce';
+import { debouncedAction, hasDeployActionInQueue, type ActionKey } from '../base/debounce';
 import { selectIvyProjectDialog } from '../base/ivyProjectSelection';
 import { logErrorMessage, logInformationMessage, logWarningMessage } from '../base/logging-util';
 import { CmsEditorRegistry } from '../editors/cms-editor/cms-editor-registry';
@@ -125,8 +125,12 @@ export class IvyProjectExplorer {
     m2eDepsWatcher.onDidCreate(deployProject);
     m2eDepsWatcher.onDidChange(deployProject);
     const targetWatcher = workspace.createFileSystemWatcher('**/target/classes/**/*.*');
-    const invalidateClassLoader = (uri: Uri) =>
+    const invalidateClassLoader = (uri: Uri) => {
+      if (hasDeployActionInQueue()) {
+        return;
+      }
       this.runEngineActionDebounced((d: string) => IvyEngineManager.instance.invalidateClassLoader(d), 'invalidate', uri);
+    };
     targetWatcher.onDidChange(invalidateClassLoader);
     targetWatcher.onDidCreate(invalidateClassLoader);
     targetWatcher.onDidDelete(invalidateClassLoader);
@@ -192,12 +196,13 @@ export class IvyProjectExplorer {
     action(project);
   }
 
-  private async runEngineActionDebounced(action: (projectDir: string) => Promise<void>, actionKey: 'deploy' | 'invalidate', uri?: Uri) {
+  private async runEngineActionDebounced(action: (projectDir: string) => Promise<void>, actionKey: ActionKey, uri?: Uri) {
     const project = await treeUriToProjectPath(uri, this.getIvyProjects());
     if (!project) {
       return;
     }
-    return debouncedAction(() => action(project), `${project}:actionKey:${actionKey}`, 1_000)();
+    const keyPrefix = actionKey === 'invalidate' ? undefined : project;
+    return debouncedAction(() => action(project), actionKey, keyPrefix)();
   }
 
   private async addProject(selection: TreeSelection) {


### PR DESCRIPTION
deploy and invalidate requests are debounced
- we no more need to send a invalidate request, if there is a deploy in the queue (deploy makes invalidate for all projects)
- invalidate is no more possible on project level - all projects will be invalidated