### PR TITLE
chore: update raise-deps.sh to run pnpm install when not dry running

### DIFF
--- a/.ivy/raise-deps.sh
+++ b/.ivy/raise-deps.sh
@@ -25,3 +25,8 @@ for pkg in webviews/*/package.json extension/package.json package.json; do
   update_version "$pkg"
 done
 mvn --batch-mode versions:set-property versions:commit -Dproperty=openapi.version -DnewVersion=${1} -DallowSnapshots=true
+
+# Skip install, because transient dependencies are not available yet
+if [ "$DRY_RUN" = false ]; then
+  pnpm install --no-frozen-lockfile
+fi


### PR DESCRIPTION
Adds pnpm install call to skip-install logic in raise-deps.sh