### PR TITLE
XIVY-19314 Add import Ivy archive command in UI

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -881,6 +881,10 @@
         {
           "command": "engine.deployProjects",
           "when": "view == ivyProjects || view == workbench.explorer.fileView"
+        },
+        {
+          "command": "ivyProjects.importIvyProject",
+          "when": "view == ivyProjects || view == workbench.explorer.fileView"
         }
       ],
       "explorer/context": [

--- a/extension/package.json
+++ b/extension/package.json
@@ -996,6 +996,10 @@
         {
           "command": "ivyProjects.addNewProject",
           "group": "5_new@1"
+        },
+        {
+          "command": "ivyProjects.importIvyProject",
+          "group": "6_new@1"
         }
       ],
       "explorer.run": [

--- a/extension/src/base/status-bar.ts
+++ b/extension/src/base/status-bar.ts
@@ -332,9 +332,13 @@ export class StatusBar {
         id: 'installLocalMarketProduct',
         callback: () => executeCommand('ivyProjects.installLocalMarketProduct')
       },
-
       { label: 'New ...', kind: QuickPickItemKind.Separator },
-      { label: '$(repo-create) New Project', id: 'newProject', callback: () => executeCommand('ivyProjects.addNewProject') }
+      { label: '$(repo-create) New Project', id: 'newProject', callback: () => executeCommand('ivyProjects.addNewProject') },
+      {
+        label: '$(repo-create) Import Axon Ivy Project',
+        id: 'importProject',
+        callback: () => executeCommand('ivyProjects.importIvyProject')
+      }
     ];
 
     const shownQuickPickOptions =


### PR DESCRIPTION
- Add command to the left-hand side AXON IVY PROJECTS view title bar (Three dots next to AXON IVY PROJECTS)
- Add command to the left-hand file explorer view right click context menu (Right click below file explorer / Axon Ivy New... )
- Add command to the bottom of the status bar quickpick (Click statusbar > Import Axon Ivy Project)