### PR TITLE
XIVY-19338 Import project - Catch invalid IAR file names

### DIFF
--- a/extension/src/engine/api/engine-api.ts
+++ b/extension/src/engine/api/engine-api.ts
@@ -183,6 +183,10 @@ export class IvyEngineApi {
       .catch(handleAxiosError);
   }
 
+  public async getWorkspaceId() {
+    return this.workspace.id;
+  }
+
   public async processDebugServerPort() {
     return processDebugger({ baseURL: this.engineURL })
       .then(res => res.data)

--- a/extension/src/engine/api/generated/client.ts
+++ b/extension/src/engine/api/generated/client.ts
@@ -4,8 +4,8 @@
  * Axon Ivy OpenAPI
  * OpenAPI spec version: 0.0.1
  */
-import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 import axios from 'axios';
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 export interface ProjectIdentifier {
   app: string;
@@ -228,7 +228,7 @@ export type StopBpmEngineParams = {
 
 export type ImportProjectsBody = {
   file?: Blob;
-  targetPath: string,
+  targetPath?: string;
   dependentProject?: Blob;
   doConvert?: string;
 };

--- a/extension/src/engine/api/generated/client.ts
+++ b/extension/src/engine/api/generated/client.ts
@@ -228,6 +228,7 @@ export type StopBpmEngineParams = {
 
 export type ImportProjectsBody = {
   file?: Blob;
+  targetPath: string,
   dependentProject?: Blob;
   doConvert?: string;
 };
@@ -444,6 +445,9 @@ export const importProjects = (
   const formData = new FormData();
   if (importProjectsBody?.file !== undefined) {
     formData.append(`file`, importProjectsBody.file);
+  }
+  if (importProjectsBody?.targetPath !== undefined) {
+    formData.append(`targetPath`, importProjectsBody.targetPath);
   }
   if (importProjectsBody?.dependentProject !== undefined) {
     formData.append(`dependentProject`, importProjectsBody.dependentProject);

--- a/extension/src/engine/engine-manager.ts
+++ b/extension/src/engine/engine-manager.ts
@@ -337,6 +337,13 @@ export class IvyEngineManager {
     return engineInfo.version;
   }
 
+  public async getWorkspaceId() {
+    if (!this.ivyEngineApi) {
+      return;
+    }
+    return this.ivyEngineApi.getWorkspaceId();
+  }
+
   public async projects(withDependencies = false) {
     return this.ivyEngineApi?.projects(withDependencies);
   }

--- a/extension/src/market/generated/market-client.ts
+++ b/extension/src/market/generated/market-client.ts
@@ -17,21 +17,19 @@ export type ProductModelNames = { [key: string]: string };
 export type ProductModelShortDescriptions = { [key: string]: string };
 
 export interface Link {
+  rel?: string;
   href?: string;
   hreflang?: string;
+  media?: string;
   title?: string;
   type?: string;
   deprecation?: string;
   profile?: string;
   name?: string;
-  templated?: boolean;
-}
-
-export interface Links {
-  [key: string]: Link;
 }
 
 export interface ProductModel {
+  links?: Link[];
   /** Product id */
   id?: string;
   /** Product name by locale */
@@ -42,6 +40,10 @@ export interface ProductModel {
   logoUrl?: string;
   /** Product's logo url for dark mode */
   logoDarkUrl?: string;
+  /** Product's badge url */
+  badgeUrl?: string;
+  /** Product's badge url for dark mode */
+  badgeDarkUrl?: string;
   /** Type of product */
   type?: string;
   /** Tags of product */
@@ -50,7 +52,8 @@ export interface ProductModel {
   marketDirectory?: string;
   /** Whether the product is deprecated */
   deprecated?: boolean;
-  _links?: Links;
+  /** Whether the product is developed from Ivy */
+  internal?: boolean;
 }
 
 export interface MavenArtifactKey {
@@ -69,6 +72,7 @@ export interface MavenArtifactVersion {
   downloadUrl?: string;
   groupId?: string;
   productId?: string;
+  invalidArtifact?: boolean;
 }
 
 export interface MavenArtifactVersionModel {
@@ -102,7 +106,6 @@ export const FindProductsType = {
   all: 'all',
   connectors: 'connectors',
   utilities: 'utilities',
-  solutions: 'solutions',
   demos: 'demos'
 } as const;
 

--- a/extension/src/project-explorer/import-ivy-project.ts
+++ b/extension/src/project-explorer/import-ivy-project.ts
@@ -2,22 +2,27 @@ import path from 'path';
 import { Uri, window, workspace } from 'vscode';
 import type { ImportProjectsBody } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
+import { listRootsInAllWorkspaces, sanitizeProjectName } from './utils/util';
 
-export const importIvyProject = async (selectedWorkspaceUri: Uri) => {
+export const importIvyProject = async (selectedWorkspaceUri: Uri, allIvyProjectPaths: string[]) => {
   const workspaceId = await IvyEngineManager.instance.getWorkspaceId();
   if (!workspaceId) {
-    window.showErrorMessage('No workspace is currently selected. Please select a workspace before importing an Ivy project.');
     return;
   }
   const selectedTargetPath = selectedWorkspaceUri.fsPath;
-  const input = await collectImportIvyProjectParams();
-  const importProjectParams: ImportProjectsBody = { ...input, targetPath: selectedTargetPath };
-  if (input) {
-    await IvyEngineManager.instance.importIvyProject(workspaceId, importProjectParams);
+  const selectedFile = await collectImportIvyArchiveFile();
+  if (!selectedFile || !selectedFile.file) {
+    return;
   }
+  const sanitizedFileName = sanitizeProjectName(selectedFile.fileName);
+  const sanitizedFilePath = path.join(selectedTargetPath, sanitizedFileName);
+  validateAgainstExistingProjects(sanitizedFileName, selectedFile.fileName, allIvyProjectPaths);
+  await validateAgainstExistingPaths(sanitizedFilePath, selectedFile.fileName);
+  const importProjectParams: ImportProjectsBody = { ...selectedFile, targetPath: selectedTargetPath };
+  await IvyEngineManager.instance.importIvyProject(workspaceId, importProjectParams);
 };
 
-const collectImportIvyProjectParams = async () => {
+const collectImportIvyArchiveFile = async () => {
   const ivyProjectFile = await window.showOpenDialog({
     canSelectMany: false,
     title: 'Select Ivy Project Archive .iar or .zip to import',
@@ -30,10 +35,29 @@ const collectImportIvyProjectParams = async () => {
     return undefined;
   }
   const fileUri = ivyProjectFile[0];
-  const fileFsPath = fileUri.fsPath;
+  const filePath = fileUri.fsPath;
+  const fileName = path.basename(filePath);
   const fileData = await workspace.fs.readFile(fileUri);
   const regularArray = new Uint8Array(fileData);
-  const fileName = fileFsPath.split(path.sep).pop();
-  const fileObj = new File([regularArray.buffer], fileName ?? fileFsPath, { type: 'application/zip' });
-  return { file: fileObj };
+  const fileObj = new File([regularArray.buffer], fileName, { type: 'application/zip' });
+  return { file: fileObj, filePath, fileName };
+};
+
+const validateAgainstExistingProjects = (fileToImportNameSanitized: string, fileImportName: string, existingIvyProjectPaths: string[]) => {
+  const existingProjectNames = existingIvyProjectPaths.map(projectPath => path.basename(projectPath));
+  if (existingProjectNames.includes(fileToImportNameSanitized)) {
+    window.showErrorMessage(
+      `File ${fileImportName} resolves to project name ${fileToImportNameSanitized}. ` +
+        `Axon Ivy Project with ${fileToImportNameSanitized} already exists in the workspace. Please either rename the import file ${fileImportName} or delete/rename the existing project.`
+    );
+  }
+};
+
+const validateAgainstExistingPaths = async (targetImportPath: string, fileImportName: string) => {
+  const existingRootPaths = (await listRootsInAllWorkspaces()).map(folder => folder.fsPath);
+  if (existingRootPaths.includes(targetImportPath)) {
+    window.showErrorMessage(
+      `Import target after project name resolving is ${targetImportPath} which exists already in your workspace. Please either rename the import file ${fileImportName} or delete/rename the existing folder.`
+    );
+  }
 };

--- a/extension/src/project-explorer/import-ivy-project.ts
+++ b/extension/src/project-explorer/import-ivy-project.ts
@@ -3,15 +3,21 @@ import { Uri, window, workspace } from 'vscode';
 import type { ImportProjectsBody } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
 
-export const importIvyProject = async (workspaceUri: Uri) => {
-  const workspaceId = path.basename(workspaceUri.fsPath);
+export const importIvyProject = async (selectedWorkspaceUri: Uri) => {
+  const workspaceId = await IvyEngineManager.instance.getWorkspaceId();
+  if (!workspaceId) {
+    window.showErrorMessage('No workspace is currently selected. Please select a workspace before importing an Ivy project.');
+    return;
+  }
+  const selectedTargetPath = selectedWorkspaceUri.fsPath;
   const input = await collectImportIvyProjectParams();
+  const importProjectParams: ImportProjectsBody = { ...input, targetPath: selectedTargetPath };
   if (input) {
-    await IvyEngineManager.instance.importIvyProject(workspaceId, input);
+    await IvyEngineManager.instance.importIvyProject(workspaceId, importProjectParams);
   }
 };
 
-const collectImportIvyProjectParams = async (): Promise<ImportProjectsBody | undefined> => {
+const collectImportIvyProjectParams = async () => {
   const ivyProjectFile = await window.showOpenDialog({
     canSelectMany: false,
     title: 'Select Ivy Project Archive .iar or .zip to import',

--- a/extension/src/project-explorer/import-ivy-project.ts
+++ b/extension/src/project-explorer/import-ivy-project.ts
@@ -13,7 +13,7 @@ export const importIvyProject = async (selectedWorkspaceUri: Uri) => {
   }
   const selectedTargetPath = selectedWorkspaceUri.fsPath;
   const selectedFile = await collectImportIvyArchiveFile();
-  if (!selectedFile || !selectedFile.filePath) {
+  if (!selectedFile) {
     return;
   }
   const fileImportPath = selectedFile.filePath;

--- a/extension/src/project-explorer/import-ivy-project.ts
+++ b/extension/src/project-explorer/import-ivy-project.ts
@@ -1,9 +1,10 @@
+import fs from 'fs';
 import path from 'path';
 import { Uri, window, workspace } from 'vscode';
 import { logErrorMessage } from '../base/logging-util';
 import type { ImportProjectsBody } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
-import { listRootsInAllWorkspaces, sanitizeProjectName } from './utils/util';
+import { sanitizeProjectName } from './utils/util';
 
 export const importIvyProject = async (selectedWorkspaceUri: Uri) => {
   const activeWorkspaceId = await IvyEngineManager.instance.getWorkspaceId();
@@ -12,7 +13,7 @@ export const importIvyProject = async (selectedWorkspaceUri: Uri) => {
   }
   const selectedTargetPath = selectedWorkspaceUri.fsPath;
   const selectedFile = await collectImportIvyArchiveFile();
-  if (!selectedFile || !selectedFile.file) {
+  if (!selectedFile || !selectedFile.filePath) {
     return;
   }
   const fileImportPath = selectedFile.filePath;
@@ -30,8 +31,7 @@ Please either rename the import file ${fileImportName} or delete/rename the exis
     return;
   }
 
-  const existingRootPaths = (await listRootsInAllWorkspaces()).map(folder => folder.fsPath);
-  if (existingRootPaths.includes(targetImportFolderPath)) {
+  if (fs.existsSync(targetImportFolderPath)) {
     logErrorMessage(
       `Import target folder after project name resolution is ${targetImportFolderPath} which already exists in your workspace.
 Please either rename the import file ${fileImportName} or delete/rename the existing folder.`

--- a/extension/src/project-explorer/import-ivy-project.ts
+++ b/extension/src/project-explorer/import-ivy-project.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { Uri, window, workspace } from 'vscode';
+import { logErrorMessage } from '../base/logging-util';
 import type { ImportProjectsBody } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
 import { listRootsInAllWorkspaces, sanitizeProjectName } from './utils/util';
@@ -14,10 +15,15 @@ export const importIvyProject = async (selectedWorkspaceUri: Uri, allIvyProjectP
   if (!selectedFile || !selectedFile.file) {
     return;
   }
-  const sanitizedFileName = sanitizeProjectName(selectedFile.fileName);
+  const fileName = path.basename(selectedFile.filePath);
+  const sanitizedFileName = sanitizeProjectName(fileName);
+  if (!validateAgainstExistingProjects(sanitizedFileName, fileName, selectedFile.filePath, allIvyProjectPaths)) {
+    return;
+  }
   const sanitizedFilePath = path.join(selectedTargetPath, sanitizedFileName);
-  validateAgainstExistingProjects(sanitizedFileName, selectedFile.fileName, allIvyProjectPaths);
-  await validateAgainstExistingPaths(sanitizedFilePath, selectedFile.fileName);
+  if (!(await validateAgainstExistingPaths(sanitizedFilePath, fileName))) {
+    return;
+  }
   const importProjectParams: ImportProjectsBody = { ...selectedFile, targetPath: selectedTargetPath };
   await IvyEngineManager.instance.importIvyProject(workspaceId, importProjectParams);
 };
@@ -36,28 +42,37 @@ const collectImportIvyArchiveFile = async () => {
   }
   const fileUri = ivyProjectFile[0];
   const filePath = fileUri.fsPath;
-  const fileName = path.basename(filePath);
   const fileData = await workspace.fs.readFile(fileUri);
   const regularArray = new Uint8Array(fileData);
-  const fileObj = new File([regularArray.buffer], fileName, { type: 'application/zip' });
-  return { file: fileObj, filePath, fileName };
+  const fileObj = new File([regularArray.buffer], path.basename(filePath), { type: 'application/zip' });
+  return { file: fileObj, filePath };
 };
 
-const validateAgainstExistingProjects = (fileToImportNameSanitized: string, fileImportName: string, existingIvyProjectPaths: string[]) => {
+const validateAgainstExistingProjects = (
+  fileToImportNameSanitized: string,
+  fileImportName: string,
+  fileImportPath: string,
+  existingIvyProjectPaths: string[]
+) => {
   const existingProjectNames = existingIvyProjectPaths.map(projectPath => path.basename(projectPath));
   if (existingProjectNames.includes(fileToImportNameSanitized)) {
-    window.showErrorMessage(
-      `File ${fileImportName} resolves to project name ${fileToImportNameSanitized}. ` +
-        `Axon Ivy Project with ${fileToImportNameSanitized} already exists in the workspace. Please either rename the import file ${fileImportName} or delete/rename the existing project.`
+    logErrorMessage(
+      `File ${fileImportPath} resolves to project name "${fileToImportNameSanitized}".
+Axon Ivy Project with name "${fileToImportNameSanitized}" already exists in the workspace.
+Please either rename the import file ${fileImportName} or delete/rename the existing project.`
     );
+    return false;
   }
+  return true;
 };
 
 const validateAgainstExistingPaths = async (targetImportPath: string, fileImportName: string) => {
   const existingRootPaths = (await listRootsInAllWorkspaces()).map(folder => folder.fsPath);
   if (existingRootPaths.includes(targetImportPath)) {
-    window.showErrorMessage(
-      `Import target after project name resolving is ${targetImportPath} which exists already in your workspace. Please either rename the import file ${fileImportName} or delete/rename the existing folder.`
+    logErrorMessage(
+      `Import target folder after project name resolution is ${targetImportPath} which already exists in your workspace.\nPlease either rename the import file ${fileImportName} or delete/rename the existing folder.`
     );
+    return false;
   }
+  return true;
 };

--- a/extension/src/project-explorer/import-ivy-project.ts
+++ b/extension/src/project-explorer/import-ivy-project.ts
@@ -6,8 +6,8 @@ import { IvyEngineManager } from '../engine/engine-manager';
 import { listRootsInAllWorkspaces, sanitizeProjectName } from './utils/util';
 
 export const importIvyProject = async (selectedWorkspaceUri: Uri) => {
-  const workspaceId = await IvyEngineManager.instance.getWorkspaceId();
-  if (!workspaceId) {
+  const activeWorkspaceId = await IvyEngineManager.instance.getWorkspaceId();
+  if (!activeWorkspaceId) {
     return;
   }
   const selectedTargetPath = selectedWorkspaceUri.fsPath;
@@ -15,12 +15,12 @@ export const importIvyProject = async (selectedWorkspaceUri: Uri) => {
   if (!selectedFile || !selectedFile.file) {
     return;
   }
-  const existingIvyProjectNames = ((await IvyEngineManager.instance.projects(false)) ?? []).map(pIdentifier => pIdentifier.id.project);
   const fileImportPath = selectedFile.filePath;
-  const fileImportName = path.basename(selectedFile.filePath);
+  const fileImportName = path.basename(fileImportPath);
   const sanitizedFileName = sanitizeProjectName(fileImportName);
-  const sanitizedFilePath = path.join(selectedTargetPath, sanitizedFileName);
+  const targetImportFolderPath = path.join(selectedTargetPath, sanitizedFileName);
 
+  const existingIvyProjectNames = ((await IvyEngineManager.instance.projects(false)) ?? []).map(pIdentifier => pIdentifier.id.project);
   if (existingIvyProjectNames.includes(sanitizedFileName)) {
     logErrorMessage(
       `File ${fileImportPath} resolves to project name "${sanitizedFileName}".
@@ -31,17 +31,16 @@ Please either rename the import file ${fileImportName} or delete/rename the exis
   }
 
   const existingRootPaths = (await listRootsInAllWorkspaces()).map(folder => folder.fsPath);
-
-  if (existingRootPaths.includes(sanitizedFilePath)) {
+  if (existingRootPaths.includes(targetImportFolderPath)) {
     logErrorMessage(
-      `Import target folder after project name resolution is ${sanitizedFilePath} which already exists in your workspace.
+      `Import target folder after project name resolution is ${targetImportFolderPath} which already exists in your workspace.
 Please either rename the import file ${fileImportName} or delete/rename the existing folder.`
     );
     return;
   }
 
   const importProjectParams: ImportProjectsBody = { ...selectedFile, targetPath: selectedTargetPath };
-  await IvyEngineManager.instance.importIvyProject(workspaceId, importProjectParams);
+  await IvyEngineManager.instance.importIvyProject(activeWorkspaceId, importProjectParams);
 };
 
 const collectImportIvyArchiveFile = async () => {

--- a/extension/src/project-explorer/import-ivy-project.ts
+++ b/extension/src/project-explorer/import-ivy-project.ts
@@ -5,7 +5,7 @@ import type { ImportProjectsBody } from '../engine/api/generated/client';
 import { IvyEngineManager } from '../engine/engine-manager';
 import { listRootsInAllWorkspaces, sanitizeProjectName } from './utils/util';
 
-export const importIvyProject = async (selectedWorkspaceUri: Uri, allIvyProjectPaths: string[]) => {
+export const importIvyProject = async (selectedWorkspaceUri: Uri) => {
   const workspaceId = await IvyEngineManager.instance.getWorkspaceId();
   if (!workspaceId) {
     return;
@@ -15,15 +15,31 @@ export const importIvyProject = async (selectedWorkspaceUri: Uri, allIvyProjectP
   if (!selectedFile || !selectedFile.file) {
     return;
   }
-  const fileName = path.basename(selectedFile.filePath);
-  const sanitizedFileName = sanitizeProjectName(fileName);
-  if (!validateAgainstExistingProjects(sanitizedFileName, fileName, selectedFile.filePath, allIvyProjectPaths)) {
-    return;
-  }
+  const existingIvyProjectNames = ((await IvyEngineManager.instance.projects(false)) ?? []).map(pIdentifier => pIdentifier.id.project);
+  const fileImportPath = selectedFile.filePath;
+  const fileImportName = path.basename(selectedFile.filePath);
+  const sanitizedFileName = sanitizeProjectName(fileImportName);
   const sanitizedFilePath = path.join(selectedTargetPath, sanitizedFileName);
-  if (!(await validateAgainstExistingPaths(sanitizedFilePath, fileName))) {
+
+  if (existingIvyProjectNames.includes(sanitizedFileName)) {
+    logErrorMessage(
+      `File ${fileImportPath} resolves to project name "${sanitizedFileName}".
+Axon Ivy Project with name "${sanitizedFileName}" already exists in the workspace.
+Please either rename the import file ${fileImportName} or delete/rename the existing project.`
+    );
     return;
   }
+
+  const existingRootPaths = (await listRootsInAllWorkspaces()).map(folder => folder.fsPath);
+
+  if (existingRootPaths.includes(sanitizedFilePath)) {
+    logErrorMessage(
+      `Import target folder after project name resolution is ${sanitizedFilePath} which already exists in your workspace.
+Please either rename the import file ${fileImportName} or delete/rename the existing folder.`
+    );
+    return;
+  }
+
   const importProjectParams: ImportProjectsBody = { ...selectedFile, targetPath: selectedTargetPath };
   await IvyEngineManager.instance.importIvyProject(workspaceId, importProjectParams);
 };
@@ -46,34 +62,4 @@ const collectImportIvyArchiveFile = async () => {
   const regularArray = new Uint8Array(fileData);
   const fileObj = new File([regularArray.buffer], path.basename(filePath), { type: 'application/zip' });
   return { file: fileObj, filePath };
-};
-
-const validateAgainstExistingProjects = (
-  fileToImportNameSanitized: string,
-  fileImportName: string,
-  fileImportPath: string,
-  existingIvyProjectPaths: string[]
-) => {
-  const existingProjectNames = existingIvyProjectPaths.map(projectPath => path.basename(projectPath));
-  if (existingProjectNames.includes(fileToImportNameSanitized)) {
-    logErrorMessage(
-      `File ${fileImportPath} resolves to project name "${fileToImportNameSanitized}".
-Axon Ivy Project with name "${fileToImportNameSanitized}" already exists in the workspace.
-Please either rename the import file ${fileImportName} or delete/rename the existing project.`
-    );
-    return false;
-  }
-  return true;
-};
-
-const validateAgainstExistingPaths = async (targetImportPath: string, fileImportName: string) => {
-  const existingRootPaths = (await listRootsInAllWorkspaces()).map(folder => folder.fsPath);
-  if (existingRootPaths.includes(targetImportPath)) {
-    logErrorMessage(
-      `Import target folder after project name resolution is ${targetImportPath} which already exists in your workspace.
-Please either rename the import file ${fileImportName} or delete/rename the existing folder.`
-    );
-    return false;
-  }
-  return true;
 };

--- a/extension/src/project-explorer/import-ivy-project.ts
+++ b/extension/src/project-explorer/import-ivy-project.ts
@@ -70,7 +70,8 @@ const validateAgainstExistingPaths = async (targetImportPath: string, fileImport
   const existingRootPaths = (await listRootsInAllWorkspaces()).map(folder => folder.fsPath);
   if (existingRootPaths.includes(targetImportPath)) {
     logErrorMessage(
-      `Import target folder after project name resolution is ${targetImportPath} which already exists in your workspace.\nPlease either rename the import file ${fileImportName} or delete/rename the existing folder.`
+      `Import target folder after project name resolution is ${targetImportPath} which already exists in your workspace.
+Please either rename the import file ${fileImportName} or delete/rename the existing folder.`
     );
     return false;
   }

--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -250,13 +250,12 @@ export class IvyProjectExplorer {
   }
 
   private async importIvyProject(selection: TreeSelection) {
-    const allIvyProjectPaths = await this.getIvyProjects();
     const selectedWorkspaceUri = await this.selectWorkspace(selection);
     if (!selectedWorkspaceUri) {
       logInformationMessage('No valid workspace selected.');
       return;
     }
-    await importIvyProject(selectedWorkspaceUri, allIvyProjectPaths);
+    await importIvyProject(selectedWorkspaceUri);
   }
 
   private async installLocalMarketProduct(selection: TreeSelection) {

--- a/extension/src/project-explorer/ivy-project-explorer.ts
+++ b/extension/src/project-explorer/ivy-project-explorer.ts
@@ -206,7 +206,7 @@ export class IvyProjectExplorer {
   private async addProject(selection: TreeSelection) {
     const selectedUri = await this.selectWorkspace(selection);
     if (!selectedUri) {
-      logInformationMessage('No valid workspace selected, dialog aborted.');
+      logInformationMessage('No valid workspace selected.');
       return;
     }
     const existingIvyProjects = await this.getIvyProjects();
@@ -250,12 +250,13 @@ export class IvyProjectExplorer {
   }
 
   private async importIvyProject(selection: TreeSelection) {
+    const allIvyProjectPaths = await this.getIvyProjects();
     const selectedWorkspaceUri = await this.selectWorkspace(selection);
     if (!selectedWorkspaceUri) {
-      logInformationMessage('No valid workspace selected, dialog aborted.');
+      logInformationMessage('No valid workspace selected.');
       return;
     }
-    await importIvyProject(selectedWorkspaceUri);
+    await importIvyProject(selectedWorkspaceUri, allIvyProjectPaths);
   }
 
   private async installLocalMarketProduct(selection: TreeSelection) {

--- a/extension/src/project-explorer/utils/util.test.ts
+++ b/extension/src/project-explorer/utils/util.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest';
-import { validateDotSeparatedName, validateNamespace, validateProjectArtifactName, validateProjectName } from './util';
+import { sanitizeProjectName, validateDotSeparatedName, validateNamespace, validateProjectArtifactName, validateProjectName } from './util';
 
 vi.mock('vscode', () => ({
   FileType: { File: 1, Directory: 2 },
@@ -228,5 +228,37 @@ test.describe('validateProjectArtifactName', () => {
     expect(validateProjectArtifactName(' ab')).toBeTruthy();
     expect(validateProjectArtifactName('ab ')).toBeTruthy();
     expect(validateProjectArtifactName('a b')).toBeTruthy();
+  });
+});
+
+test.describe('sanitizeProjectName', () => {
+  test('removes a trailing .iar extension', () => {
+    expect(sanitizeProjectName('MyProject.iar')).toBe('MyProject');
+  });
+
+  test('removes all .iar occurences', () => {
+    expect(sanitizeProjectName('My.iarProject.iar')).toBe('MyProject');
+  });
+
+  test('replaces dots with hyphens', () => {
+    expect(sanitizeProjectName('my.project.name.iar')).toBe('my-project-name');
+  });
+
+  test('replaces invalid characters with underscores', () => {
+    expect(sanitizeProjectName('my project@name!.iar')).toBe('my_project_name_');
+  });
+
+  test('keeps letters, digits, underscores, and hyphens', () => {
+    expect(sanitizeProjectName('abc_123-XYZ.iar')).toBe('abc_123-XYZ');
+  });
+
+  test('truncates to 40 characters', () => {
+    const longName = 'abcdefghijklmnopqrstuvwxyz0123456789-extra-chars.iar';
+    expect(sanitizeProjectName(longName)).toHaveLength(40);
+    expect(sanitizeProjectName(longName)).toBe('abcdefghijklmnopqrstuvwxyz0123456789-ext');
+  });
+
+  test('does not modify strings without special characters', () => {
+    expect(sanitizeProjectName('CleanName')).toBe('CleanName');
   });
 });

--- a/extension/src/project-explorer/utils/util.ts
+++ b/extension/src/project-explorer/utils/util.ts
@@ -76,21 +76,6 @@ export const getWorkspaceFolder = async () => {
   return await window.showWorkspaceFolderPick().then(folder => folder?.uri);
 };
 
-export const listRootsInAllWorkspaces = async () => {
-  const workspaceFolders = workspace.workspaceFolders ?? [];
-  const roots = await Promise.all(
-    workspaceFolders.map(async folder => {
-      try {
-        const entries = await workspace.fs.readDirectory(folder.uri);
-        return entries.filter(([, type]) => type === FileType.Directory).map(([name]) => Uri.joinPath(folder.uri, name));
-      } catch {
-        return [];
-      }
-    })
-  );
-  return roots.flat();
-};
-
 export const validateProjectArtifactName = (value: string) => {
   const pattern = /^[a-zA-Z_][\w]*$/;
   if (pattern.test(value)) {

--- a/extension/src/project-explorer/utils/util.ts
+++ b/extension/src/project-explorer/utils/util.ts
@@ -76,6 +76,21 @@ export const getWorkspaceFolder = async () => {
   return await window.showWorkspaceFolderPick().then(folder => folder?.uri);
 };
 
+export const listRootsInAllWorkspaces = async () => {
+  const workspaceFolders = workspace.workspaceFolders ?? [];
+  const roots = await Promise.all(
+    workspaceFolders.map(async folder => {
+      try {
+        const entries = await workspace.fs.readDirectory(folder.uri);
+        return entries.filter(([, type]) => type === FileType.Directory).map(([name]) => Uri.joinPath(folder.uri, name));
+      } catch {
+        return [];
+      }
+    })
+  );
+  return roots.flat();
+};
+
 export const validateProjectArtifactName = (value: string) => {
   const pattern = /^[a-zA-Z_][\w]*$/;
   if (pattern.test(value)) {

--- a/extension/src/project-explorer/utils/util.ts
+++ b/extension/src/project-explorer/utils/util.ts
@@ -107,3 +107,15 @@ export const validateNamespace = (value: string) => {
   }
   return 'Enter Namespace separated by "/" -- Only letters, numbers, and underscores are allowed -- Spaces allowed within words -- Empty allowed.';
 };
+
+export const sanitizeProjectName = (fileName: string) => {
+  /**
+   * Sanitize logic is duplicated from core ProjectService.java sanitizeProjectName
+   * Must be kept in sync with that logic
+   */
+  const sanitized = fileName
+    .replace(/\.iar/gi, '') // remove ALL .iar, also in the middle of the filename
+    .replace(/\./g, '-')
+    .replace(/[^\w-]/g, '_');
+  return sanitized.slice(0, 40);
+};

--- a/playwright/tests/integration/explorer/import-ivy-project.spec.ts
+++ b/playwright/tests/integration/explorer/import-ivy-project.spec.ts
@@ -5,6 +5,7 @@ import { downloadIar } from '~/utils/download-iar';
 import { empty } from '../../workspaces/workspace';
 
 const ivyProjectIar = 'ivy-project.iar';
+const ivyProjectIarDuplicateSanitized = 'ivy.project.iar';
 
 test.use({ workspace: empty });
 
@@ -20,4 +21,25 @@ test('Import up-to-date Ivy Project', async ({ wsPage }) => {
   await wsPage.executeCommand('Refresh Explorer');
   await explorer.hasNodeExact(ivyProjectIar.replace('.iar', ''));
   await expect(wsPage.toasts).toBeHidden();
+});
+
+test('Import same project error', async ({ wsPage, tmpWorkspace }) => {
+  const explorer = new FileExplorer(wsPage);
+  await explorer.hasNodeExact(ivyProjectIar);
+  await wsPage.executeCommand('Import Axon Ivy Project Archive (.iar or .zip)');
+  await wsPage.selectItemFromQuickPick(ivyProjectIar);
+  await wsPage.executeCommand('Refresh Explorer');
+  await explorer.hasNodeExact(ivyProjectIar.replace('.iar', ''));
+  await expect(wsPage.toasts).toBeHidden();
+
+  await downloadIar(tmpWorkspace.tmpWorkspacePath, ivyProjectIarDuplicateSanitized);
+  await explorer.hasNodeExact(ivyProjectIarDuplicateSanitized);
+  await wsPage.executeCommand('Import Axon Ivy Project Archive (.iar or .zip)');
+  await wsPage.selectItemFromQuickPick(ivyProjectIarDuplicateSanitized);
+
+  await expect(wsPage.toasts).toHaveText(
+    `File ${tmpWorkspace.tmpWorkspacePath}/${ivyProjectIarDuplicateSanitized} resolves to project name "ivy-project".
+Axon Ivy Project with name "ivy-project" already exists in the workspace.
+Please either rename the import file ${ivyProjectIarDuplicateSanitized} or delete/rename the existing project.`
+  );
 });

--- a/playwright/tests/integration/explorer/import-ivy-project.spec.ts
+++ b/playwright/tests/integration/explorer/import-ivy-project.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { test } from '~/fixtures/baseTest';
 import { FileExplorer } from '~/page-objects/explorer-view';
 import { downloadIar } from '~/utils/download-iar';
-import { empty } from '../../workspaces/workspace';
+import { empty, multiRootWorkspacePath } from '../../workspaces/workspace';
 
 const ivyProjectIar = 'ivy-project.iar';
 const ivyProjectIarDuplicateSanitized = 'ivy.project.iar';
@@ -42,4 +42,25 @@ test('Import same project error', async ({ wsPage, tmpWorkspace }) => {
 Axon Ivy Project with name "ivy-project" already exists in the workspace.
 Please either rename the import file ${ivyProjectIarDuplicateSanitized} or delete/rename the existing project.`
   );
+});
+
+test.describe('Multi root workspace', () => {
+  test.use({ workspace: multiRootWorkspacePath });
+  test.skip(process.env.RUN_IN_BROWSER === 'true');
+
+  test('Import Ivy Project into multi-root workspace', async ({ wsPage, tmpWorkspace }) => {
+    const explorer = new FileExplorer(wsPage);
+    await explorer.hasNodeExact(ivyProjectIar);
+
+    await downloadIar(tmpWorkspace.tmpWorkspacePath, 'connector.iar');
+    await explorer.hasNodeExact('connector.iar');
+    await wsPage.executeCommand('Import Axon Ivy Project Archive (.iar or .zip)');
+    await wsPage.selectItemFromQuickPick('connector.iar');
+
+    await expect(wsPage.toasts).toHaveText(
+      `File ${tmpWorkspace.tmpWorkspacePath}/connector.iar resolves to project name "connector".
+  Axon Ivy Project with name "connector" already exists in the workspace.
+  Please either rename the import file connector.iar or delete/rename the existing project.`
+    );
+  });
 });

--- a/playwright/tests/integration/explorer/import-ivy-project.spec.ts
+++ b/playwright/tests/integration/explorer/import-ivy-project.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import path from 'path';
 import { test } from '~/fixtures/baseTest';
 import { FileExplorer } from '~/page-objects/explorer-view';
 import { downloadIar } from '~/utils/download-iar';
@@ -7,60 +8,84 @@ import { empty, multiRootWorkspacePath } from '../../workspaces/workspace';
 const ivyProjectIar = 'ivy-project.iar';
 const ivyProjectIarDuplicateSanitized = 'ivy.project.iar';
 
-test.use({ workspace: empty });
+test.describe('Single root workspace', () => {
+  test.use({ workspace: empty });
 
-test.beforeEach(async ({ tmpWorkspace }) => {
-  await downloadIar(tmpWorkspace.tmpWorkspacePath, ivyProjectIar);
-});
+  test.beforeEach(async ({ tmpWorkspace }) => {
+    await downloadIar(tmpWorkspace.tmpWorkspacePath, ivyProjectIar);
+  });
 
-test('Import up-to-date Ivy Project', async ({ wsPage }) => {
-  const explorer = new FileExplorer(wsPage);
-  await explorer.hasNodeExact(ivyProjectIar);
-  await wsPage.executeCommand('Import Axon Ivy Project Archive (.iar or .zip)');
-  await wsPage.selectItemFromQuickPick(ivyProjectIar);
-  await wsPage.executeCommand('Refresh Explorer');
-  await explorer.hasNodeExact(ivyProjectIar.replace('.iar', ''));
-  await expect(wsPage.toasts).toBeHidden();
-});
+  test('Import up-to-date Ivy Project', async ({ wsPage }) => {
+    const explorer = new FileExplorer(wsPage);
+    await explorer.hasNodeExact(ivyProjectIar);
+    await wsPage.executeCommand('Import Axon Ivy Project Archive (.iar or .zip)');
+    await wsPage.selectItemFromQuickPick(ivyProjectIar);
+    await wsPage.executeCommand('Refresh Explorer');
+    await explorer.hasNodeExact(ivyProjectIar.replace('.iar', ''));
+    await expect(wsPage.toasts).toBeHidden();
+  });
 
-test('Import same project error', async ({ wsPage, tmpWorkspace }) => {
-  const explorer = new FileExplorer(wsPage);
-  await explorer.hasNodeExact(ivyProjectIar);
-  await wsPage.executeCommand('Import Axon Ivy Project Archive (.iar or .zip)');
-  await wsPage.selectItemFromQuickPick(ivyProjectIar);
-  await wsPage.executeCommand('Refresh Explorer');
-  await explorer.hasNodeExact(ivyProjectIar.replace('.iar', ''));
-  await expect(wsPage.toasts).toBeHidden();
+  test('Import same project error', async ({ wsPage, tmpWorkspace }) => {
+    const explorer = new FileExplorer(wsPage);
+    await explorer.hasNodeExact(ivyProjectIar);
+    await wsPage.executeCommand('Import Axon Ivy Project Archive (.iar or .zip)');
+    await wsPage.selectItemFromQuickPick(ivyProjectIar);
+    await wsPage.executeCommand('Refresh Explorer');
+    await explorer.hasNodeExact(ivyProjectIar.replace('.iar', ''));
+    await expect(wsPage.toasts).toBeHidden();
 
-  await downloadIar(tmpWorkspace.tmpWorkspacePath, ivyProjectIarDuplicateSanitized);
-  await explorer.hasNodeExact(ivyProjectIarDuplicateSanitized);
-  await wsPage.executeCommand('Import Axon Ivy Project Archive (.iar or .zip)');
-  await wsPage.selectItemFromQuickPick(ivyProjectIarDuplicateSanitized);
+    await downloadIar(tmpWorkspace.tmpWorkspacePath, ivyProjectIarDuplicateSanitized);
+    await explorer.hasNodeExact(ivyProjectIarDuplicateSanitized);
+    await wsPage.executeCommand('Import Axon Ivy Project Archive (.iar or .zip)');
+    await wsPage.selectItemFromQuickPick(ivyProjectIarDuplicateSanitized);
 
-  await expect(wsPage.toasts).toHaveText(
-    `File ${tmpWorkspace.tmpWorkspacePath}/${ivyProjectIarDuplicateSanitized} resolves to project name "ivy-project".
-Axon Ivy Project with name "ivy-project" already exists in the workspace.
-Please either rename the import file ${ivyProjectIarDuplicateSanitized} or delete/rename the existing project.`
-  );
+    await expect(wsPage.toasts).toHaveText(
+      `File ${tmpWorkspace.tmpWorkspacePath}/${ivyProjectIarDuplicateSanitized} resolves to project name "ivy-project".
+  Axon Ivy Project with name "ivy-project" already exists in the workspace.
+  Please either rename the import file ${ivyProjectIarDuplicateSanitized} or delete/rename the existing project.`
+    );
+  });
 });
 
 test.describe('Multi root workspace', () => {
   test.use({ workspace: multiRootWorkspacePath });
   test.skip(process.env.RUN_IN_BROWSER === 'true');
 
-  test('Import Ivy Project into multi-root workspace', async ({ wsPage, tmpWorkspace }) => {
-    const explorer = new FileExplorer(wsPage);
-    await explorer.hasNodeExact(ivyProjectIar);
+  test('Import existing project by name into multi-root workspace', async ({ wsPage, tmpWorkspace }) => {
+    const iarFileName = 'connector.iar';
+    const targetFolderName = iarFileName.replace('.iar', '');
 
-    await downloadIar(tmpWorkspace.tmpWorkspacePath, 'connector.iar');
-    await explorer.hasNodeExact('connector.iar');
+    const explorer = new FileExplorer(wsPage);
+    await downloadIar(path.join(tmpWorkspace.tmpWorkspacePath, targetFolderName), iarFileName);
+
+    await explorer.hasNodeExact(iarFileName);
     await wsPage.executeCommand('Import Axon Ivy Project Archive (.iar or .zip)');
-    await wsPage.selectItemFromQuickPick('connector.iar');
+    await wsPage.selectItemFromQuickPick('ivy-project-1');
+    await wsPage.selectItemFromQuickPick(iarFileName);
 
     await expect(wsPage.toasts).toHaveText(
-      `File ${tmpWorkspace.tmpWorkspacePath}/connector.iar resolves to project name "connector".
-  Axon Ivy Project with name "connector" already exists in the workspace.
-  Please either rename the import file connector.iar or delete/rename the existing project.`
+      `File ${tmpWorkspace.tmpWorkspacePath}/${targetFolderName}/${iarFileName} resolves to project name "connector".
+Axon Ivy Project with name "connector" already exists in the workspace.
+Please either rename the import file ${iarFileName} or delete/rename the existing project.`
+    );
+  });
+
+  test('Import existing folder into multi-root workspace', async ({ wsPage, tmpWorkspace }) => {
+    const iarFileName = 'dummy.iar';
+    const targetFolderName = iarFileName.replace('.iar', '');
+
+    const explorer = new FileExplorer(wsPage);
+    await downloadIar(path.join(tmpWorkspace.tmpWorkspacePath, 'connector'), iarFileName);
+
+    await explorer.addFolder(targetFolderName);
+    await explorer.hasNodeExact(targetFolderName);
+    await wsPage.executeCommand('Import Axon Ivy Project Archive (.iar or .zip)');
+    await wsPage.selectItemFromQuickPick('connector');
+    await wsPage.selectItemFromQuickPick(iarFileName);
+
+    await expect(wsPage.toasts).toHaveText(
+      `Import target folder after project name resolution is ${tmpWorkspace.tmpWorkspacePath}/connector/${targetFolderName} which already exists in your workspace.
+Please either rename the import file ${iarFileName} or delete/rename the existing folder.`
     );
   });
 });

--- a/playwright/tests/workspaces/multiProject/multiRootWorkspace.code-workspace
+++ b/playwright/tests/workspaces/multiProject/multiRootWorkspace.code-workspace
@@ -13,6 +13,7 @@
     "files.simpleDialog.enable": true,
     "git.openRepositoryInParentFolders": "never",
     "chat.disableAIFeatures": true,
-    "java.server.launchMode": "LightWeight"
+    "java.server.launchMode": "LightWeight",
+    "redhat.telemetry.enabled": false
   }
 }


### PR DESCRIPTION
- After selecting the IAR file, sanitize and check against all existing Ivy projects in workspace as well as all existing folders on workspace root level.
- Does NOT YET work for .zip, the contents of the .zip are not validated in the frontend. The engine will throw an error, but the frontend will not print a pretty error message.